### PR TITLE
[feat] AWS S3 Service 연동

### DIFF
--- a/.github/workflows/DOCKER-CD-PROD.yml
+++ b/.github/workflows/DOCKER-CD-PROD.yml
@@ -50,6 +50,13 @@ jobs:
           echo "${{ secrets.PROD_YML }}" > ./application-prod.yml
         working-directory: ${{ env.working-directory }}
 
+      - name: aws-config.yml 생성
+        run: |
+          cd ./src/main/resources
+          touch ./aws-config.yml
+          echo "${{ secrets.AWS_CONFIG_YML }}" > ./aws-config.yml
+        working-directory: ${{ env.working-directory }}
+
       - name: 빌드
         run: |
           chmod +x gradlew

--- a/.github/workflows/DOCKER-CD-STAGING.yml
+++ b/.github/workflows/DOCKER-CD-STAGING.yml
@@ -50,6 +50,13 @@ jobs:
           echo "${{ secrets.PROD_STAGING }}" > ./application-staging.yml
         working-directory: ${{ env.working-directory }}
 
+      - name: aws-config.yml 생성
+        run: |
+          cd ./src/main/resources
+          touch ./aws-config.yml
+          echo "${{ secrets.AWS_CONFIG_YML }}" > ./aws-config.yml
+        working-directory: ${{ env.working-directory }}
+
       - name: 빌드
         run: |
           chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	//Multipart file
+	implementation("software.amazon.awssdk:bom:2.21.0")
+	implementation("software.amazon.awssdk:s3:2.21.0")
+
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }

--- a/src/main/java/org/noostak/global/config/AwsConfig.java
+++ b/src/main/java/org/noostak/global/config/AwsConfig.java
@@ -1,0 +1,52 @@
+package org.noostak.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@Getter
+public class AwsConfig {
+
+    @Value("${aws-property.s3-bucket-name}")
+    private String s3BucketName;
+
+    @Value("${aws-property.access-key}")
+    private String accessKey;
+
+    @Value("${aws-property.secret-key}")
+    private String secretKey;
+
+    @Value("${aws-property.aws-region}")
+    private String awsRegion;
+
+    @Value("${aws-property.max-file-size}")
+    private String maxFileSize;
+
+    @Bean
+    public Region getRegion() {
+
+        return Region.of(awsRegion);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public Long getMaxFileSize() {
+        try {
+            return Long.parseLong(maxFileSize);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid max file size format: " + maxFileSize, e);
+        }
+    }
+}

--- a/src/main/java/org/noostak/global/config/AwsConfig.java
+++ b/src/main/java/org/noostak/global/config/AwsConfig.java
@@ -49,4 +49,9 @@ public class AwsConfig {
             throw new IllegalArgumentException("Invalid max file size format: " + maxFileSize, e);
         }
     }
+
+    @Bean
+    public String getS3BucketName(){
+        return this.s3BucketName;
+    }
 }

--- a/src/main/java/org/noostak/global/error/core/ErrorCode.java
+++ b/src/main/java/org/noostak/global/error/core/ErrorCode.java
@@ -1,0 +1,9 @@
+package org.noostak.global.error.core;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+    int getStatusValue();
+}

--- a/src/main/java/org/noostak/global/error/core/ErrorCode.java
+++ b/src/main/java/org/noostak/global/error/core/ErrorCode.java
@@ -1,9 +1,0 @@
-package org.noostak.global.error.core;
-
-import org.springframework.http.HttpStatus;
-
-public interface ErrorCode {
-    HttpStatus getStatus();
-    String getMessage();
-    int getStatusValue();
-}

--- a/src/main/java/org/noostak/infra/FakeS3StorageImpl.java
+++ b/src/main/java/org/noostak/infra/FakeS3StorageImpl.java
@@ -1,0 +1,97 @@
+package org.noostak.infra;
+
+import org.noostak.infra.error.S3UploadErrorCode;
+import org.noostak.infra.error.S3UploadException;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+
+public class FakeS3StorageImpl implements S3Storage {
+
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+    private final S3Client s3Client;
+    private final String s3BucketName;
+    private final long maxFileSize;
+
+    private FakeS3StorageImpl(S3Client s3Client, String s3BucketName, long maxFileSize) {
+        this.s3Client = s3Client;
+        this.s3BucketName = s3BucketName;
+        this.maxFileSize = maxFileSize;
+    }
+
+
+    public static FakeS3StorageImpl of(S3Client s3Client, String s3BucketName, long maxFileSize) {
+        return new FakeS3StorageImpl(s3Client, s3BucketName, maxFileSize);
+    }
+
+    @Override
+    public String upload(String directoryPath, MultipartFile image) throws IOException {
+        final String key = directoryPath + generateImageFileName();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+
+        return key;
+    }
+
+    @Override
+    public void delete(String key) {
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new S3UploadException(S3UploadErrorCode.INVALID_EXTENSION);
+        }
+    }
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > maxFileSize) {
+            throw new S3UploadException(S3UploadErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+    @Override
+    public S3Client getS3Client() {
+        return s3Client;
+    }
+
+    @Override
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    @Override
+    public long getMaxFileSize() {
+        return maxFileSize;
+    }
+}

--- a/src/main/java/org/noostak/infra/S3Service.java
+++ b/src/main/java/org/noostak/infra/S3Service.java
@@ -45,6 +45,17 @@ public class S3Service {
         return key;
     }
 
+    public void deleteImage(String key) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(awsConfig.getS3BucketName())
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
     private String generateImageFileName() {
         return UUID.randomUUID() + ".jpg";
     }

--- a/src/main/java/org/noostak/infra/S3Service.java
+++ b/src/main/java/org/noostak/infra/S3Service.java
@@ -1,0 +1,29 @@
+package org.noostak.infra;
+
+import org.noostak.global.config.AwsConfig;
+import org.noostak.infra.error.S3UploadErrorCode;
+import org.noostak.infra.error.S3UploadException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class S3Service {
+
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+    private final AwsConfig awsConfig;
+
+    public S3Service(AwsConfig awsConfig) {
+        this.awsConfig = awsConfig;
+    }
+
+}

--- a/src/main/java/org/noostak/infra/S3Storage.java
+++ b/src/main/java/org/noostak/infra/S3Storage.java
@@ -1,0 +1,18 @@
+package org.noostak.infra;
+
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.io.IOException;
+
+public interface S3Storage {
+    String upload(String directoryPath, MultipartFile image) throws IOException;
+
+    void delete(String key);
+
+    S3Client getS3Client();
+
+    String getS3BucketName();
+
+    long getMaxFileSize();
+}

--- a/src/main/java/org/noostak/infra/S3StorageImpl.java
+++ b/src/main/java/org/noostak/infra/S3StorageImpl.java
@@ -1,0 +1,98 @@
+package org.noostak.infra;
+
+import org.noostak.infra.error.S3UploadErrorCode;
+import org.noostak.infra.error.S3UploadException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+
+@Component
+public class S3StorageImpl implements S3Storage {
+
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+    private final S3Client s3Client;
+    private final String s3BucketName;
+    private final long maxFileSize;
+
+    private S3StorageImpl(S3Client s3Client, String s3BucketName, long maxFileSize) {
+        this.s3Client = s3Client;
+        this.s3BucketName = s3BucketName;
+        this.maxFileSize = maxFileSize;
+    }
+
+
+    public static S3StorageImpl of(S3Client s3Client, String s3BucketName, long maxFileSize) {
+        return new S3StorageImpl(s3Client, s3BucketName, maxFileSize);
+    }
+
+    @Override
+    public String upload(String directoryPath, MultipartFile image) throws IOException {
+        final String key = directoryPath + generateImageFileName();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return key;
+    }
+
+    @Override
+    public void delete(String key) {
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(s3BucketName)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new S3UploadException(S3UploadErrorCode.INVALID_EXTENSION);
+        }
+    }
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > maxFileSize) {
+            throw new S3UploadException(S3UploadErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+    @Override
+    public S3Client getS3Client() {
+        return s3Client;
+    }
+
+    @Override
+    public String getS3BucketName() {
+        return s3BucketName;
+    }
+
+    @Override
+    public long getMaxFileSize() {
+        return maxFileSize;
+    }
+}

--- a/src/main/java/org/noostak/infra/error/S3UploadErrorCode.java
+++ b/src/main/java/org/noostak/infra/error/S3UploadErrorCode.java
@@ -1,0 +1,26 @@
+package org.noostak.infra.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum S3UploadErrorCode {
+    INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "이미지 확장자는 jpg, png, webp만 가능합니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 5MB를 넘을 수 없습니다.");
+
+    public static final String PREFIX = "[S3 UPLOAD ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+
+    public int getStatusValue() {
+        return status.value();
+    }
+}

--- a/src/main/java/org/noostak/infra/error/S3UploadErrorCode.java
+++ b/src/main/java/org/noostak/infra/error/S3UploadErrorCode.java
@@ -3,11 +3,12 @@ package org.noostak.infra.error;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.noostak.global.error.core.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum S3UploadErrorCode {
+public enum S3UploadErrorCode implements ErrorCode {
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "이미지 확장자는 jpg, png, webp만 가능합니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 5MB를 넘을 수 없습니다.");
 

--- a/src/main/java/org/noostak/infra/error/S3UploadException.java
+++ b/src/main/java/org/noostak/infra/error/S3UploadException.java
@@ -1,0 +1,7 @@
+package org.noostak.infra.error;
+
+public class S3UploadException extends RuntimeException{
+    public S3UploadException(S3UploadErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/src/test/java/org/noostak/infra/S3ServiceTest.java
+++ b/src/test/java/org/noostak/infra/S3ServiceTest.java
@@ -1,0 +1,116 @@
+package org.noostak.infra;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.noostak.global.config.AwsConfig;
+import org.noostak.infra.error.S3UploadErrorCode;
+import org.noostak.infra.error.S3UploadException;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class S3ServiceTest {
+
+    private final AwsConfig awsConfig = mock(AwsConfig.class);
+    private final S3Client s3Client = mock(S3Client.class);
+
+    private final S3Service s3Service = new S3Service(awsConfig);
+
+    @Nested
+    @DisplayName("이미지 업로드 테스트")
+    class UploadImageTests {
+
+        @Test
+        @DisplayName("이미지 업로드 - 성공")
+        void uploadImage_success() throws IOException {
+            // Given
+            String directoryPath = "images/";
+            MultipartFile image = new MockMultipartFile(
+                    "image",
+                    "test.jpg",
+                    "image/jpeg",
+                    new byte[]{1, 2, 3, 4}
+            );
+
+            when(awsConfig.getS3Client()).thenReturn(s3Client);
+            when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
+            when(awsConfig.getMaxFileSize()).thenReturn(1024L * 1024 * 2);
+
+            // When
+            String result = s3Service.uploadImage(directoryPath, image);
+
+            // Then
+            assertThat(result).startsWith(directoryPath).endsWith(".jpg");
+            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        }
+
+
+        @Test
+        @DisplayName("이미지 업로드 - 잘못된 확장자")
+        void uploadImage_invalidExtension() {
+            // Given
+            String directoryPath = "images/";
+            MultipartFile image = new MockMultipartFile(
+                    "image",
+                    "test.txt",
+                    "text/plain",
+                    new byte[]{1, 2, 3, 4}
+            );
+
+            // When & Then
+            assertThatThrownBy(() -> s3Service.uploadImage(directoryPath, image))
+                    .isInstanceOf(S3UploadException.class)
+                    .hasMessageContaining(S3UploadErrorCode.INVALID_EXTENSION.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미지 업로드 - 파일 크기 초과")
+        void uploadImage_fileSizeExceedsLimit() {
+            // Given
+            String directoryPath = "images/";
+            MultipartFile image = new MockMultipartFile(
+                    "image",
+                    "large.jpg",
+                    "image/jpeg",
+                    new byte[3 * 1024 * 1024]
+            );
+            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
+
+            // When & Then
+            assertThatThrownBy(() -> s3Service.uploadImage(directoryPath, image))
+                    .isInstanceOf(S3UploadException.class)
+                    .hasMessageContaining(S3UploadErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("이미지 삭제 테스트")
+    class DeleteImageTests {
+
+        @Test
+        @DisplayName("이미지 삭제 - 성공")
+        void deleteImage_success() throws IOException {
+            // Given
+            String key = "images/test.jpg";
+            when(awsConfig.getS3Client()).thenReturn(s3Client);
+            when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
+
+            // When
+            s3Service.deleteImage(key);
+
+            // Then
+            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+        }
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** Backend 서버 - AWS S3 서비스 연동을 구현 하였습니다.
- **핵심 변경사항:** 서비스 연동 관련 구현 및 테스트 코드를 작성 하였습니다. aws configuration과 관련된 application.yml 파일도 수정하였습니다.

# 🛠️ What’s been done?
- **주요 변경사항**
  - S3Service 구현
  - aws-config.yml 파일 추가
    - s3-bucket-name, access-key, secret-key, aws-region, max-file-size 프로퍼티 추가
      <img width="533" alt="image" src="https://github.com/user-attachments/assets/4fe81645-f136-4b6e-8082-c2667eff486c" />
  - application.yml 수정
    -  aws-config.yml파일을 import하는 구문 추가
  - S3 이미지 업로드 및 이미지 삭제에 관한 테스트 코드 작성
  - git actions에 AWS_CONFIG_YML 시크릿 추가

# 🧪 Testing Details
- **테스트 코드 및 결과**
  - 이미지 업로드 성공, 이미지 업로드 실패, 이미지 삭제 성공 테스트 케이스를 통과 하였습니다.
  - 모든 테스트가 정상적으로 통과하였음을 확인하였습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - AWS S3 연동을 위해 application.yml 파일을 수정 하였습니다. 해당 내용을 기반으로 STAGING_YML를 수정해도 되는지 검토 부탁드립니다.
  - S3관련 프로퍼티를 기존 설정과 분리하기 위해, aws-config.yml을 따로 두고, application.yml이 이를 import하도록 수정 하였습니다. 해당 방식 적용 여부에 대한 의견 부탁 드립니다.
    <img width="329" alt="image" src="https://github.com/user-attachments/assets/d3a863b7-944e-453c-9d37-26fe339e3b5b" />

# 🎯 Related Issues
- #18 