### PR TITLE
[refactor] 멤버 이름 검증 방식 변경 (블랙 리스트 -> 화이트 리스트)

### DIFF
--- a/src/main/java/org/noostak/member/common/MemberErrorCode.java
+++ b/src/main/java/org/noostak/member/common/MemberErrorCode.java
@@ -10,9 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NAME_NOT_EMPTY(HttpStatus.BAD_REQUEST, "멤버 이름은 비어 있을 수 없습니다."),
     MEMBER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "멤버 이름의 길이는 15글자를 넘을 수 없습니다."),
-    MEMBER_NAME_INVALID_LANGUAGE(HttpStatus.BAD_REQUEST, "멤버 이름에는 한글, 영문만 포함될 수 있습니다."),
-    MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS(HttpStatus.BAD_REQUEST, "멤버 이름에는 특수 문자가 포함될 수 없습니다."),
-    MEMBER_NAME_CANNOT_CONTAIN_NUMBERS(HttpStatus.BAD_REQUEST, "멤버 이름에는 숫자가 포함될 수 없습니다."),
+    INVALID_MEMBER_NAME(HttpStatus.BAD_REQUEST, "멤버 이름에는 한글, 영문, 이모지만 포함될 수 있습니다."),
 
     MEMBER_PROFILE_IMAGE_KEY_NOT_EMPTY(HttpStatus.BAD_REQUEST, "멤버 프로필 이미지 키는 비어 있을 수 없습니다."),
 

--- a/src/main/java/org/noostak/member/common/MemberErrorCode.java
+++ b/src/main/java/org/noostak/member/common/MemberErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NAME_NOT_EMPTY(HttpStatus.BAD_REQUEST, "멤버 이름은 비어 있을 수 없습니다."),
     MEMBER_NAME_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "멤버 이름의 길이는 15글자를 넘을 수 없습니다."),
-    MEMBER_NAME_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "멤버 이름에는 특수 문자가 포함될 수 없습니다."),
+    MEMBER_NAME_INVALID_LANGUAGE(HttpStatus.BAD_REQUEST, "멤버 이름에는 한글, 영문만 포함될 수 있습니다."),
+    MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS(HttpStatus.BAD_REQUEST, "멤버 이름에는 특수 문자가 포함될 수 없습니다."),
+    MEMBER_NAME_CANNOT_CONTAIN_NUMBERS(HttpStatus.BAD_REQUEST, "멤버 이름에는 숫자가 포함될 수 없습니다."),
 
     MEMBER_PROFILE_IMAGE_KEY_NOT_EMPTY(HttpStatus.BAD_REQUEST, "멤버 프로필 이미지 키는 비어 있을 수 없습니다."),
 

--- a/src/main/java/org/noostak/member/domain/vo/MemberName.java
+++ b/src/main/java/org/noostak/member/domain/vo/MemberName.java
@@ -8,6 +8,8 @@ import org.noostak.member.common.MemberException;
 @Embeddable
 @EqualsAndHashCode
 public class MemberName {
+    private static final int MAX_LENGTH = 15;
+
     private final String name;
 
     protected MemberName() {
@@ -30,7 +32,9 @@ public class MemberName {
     private void validateName(String name) {
         validateEmpty(name);
         validateLength(name);
+        validateNumbers(name);
         validateSpecialCharacters(name);
+        validateInvalidLanguages(name);
     }
 
     private void validateEmpty(String memberName) {
@@ -40,15 +44,43 @@ public class MemberName {
     }
 
     private void validateLength(String memberName) {
-        if (memberName.length() > 15) {
+        if (memberName.length() > MAX_LENGTH) {
             throw new MemberException(MemberErrorCode.MEMBER_NAME_LENGTH_EXCEEDED);
         }
     }
 
-    private void validateSpecialCharacters(String name) {
-        if (name.matches(".*[!@#$%^&*()_+=|<>?{}\\[\\]~-].*")) {
-            throw new MemberException(MemberErrorCode.MEMBER_NAME_INVALID_CHARACTER);
+    private void validateNumbers(String name) {
+        if (name.chars().anyMatch(Character::isDigit)) {
+            throw new MemberException(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_NUMBERS);
         }
+    }
+
+    private void validateSpecialCharacters(String name) {
+        if (name.chars().mapToObj(c -> (char) c).anyMatch(this::isSpecialCharacter)) {
+            throw new MemberException(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS);
+        }
+    }
+
+    private void validateInvalidLanguages(String name) {
+        if (name.chars().mapToObj(c -> (char) c).anyMatch(this::isInvalidLanguage)) {
+            throw new MemberException(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE);
+        }
+    }
+
+    private boolean isKorean(char c) {
+        return (c >= '가' && c <= '힣');
+    }
+
+    private boolean isEnglish(char c) {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    private boolean isSpecialCharacter(char c) {
+        return !Character.isLetterOrDigit(c);
+    }
+
+    private boolean isInvalidLanguage(char c) {
+        return !isKorean(c) && !isEnglish(c);
     }
 
     @Override

--- a/src/main/java/org/noostak/member/domain/vo/MemberName.java
+++ b/src/main/java/org/noostak/member/domain/vo/MemberName.java
@@ -5,10 +5,13 @@ import lombok.EqualsAndHashCode;
 import org.noostak.member.common.MemberErrorCode;
 import org.noostak.member.common.MemberException;
 
+import java.util.regex.Pattern;
+
 @Embeddable
 @EqualsAndHashCode
 public class MemberName {
     private static final int MAX_LENGTH = 15;
+    private static final Pattern INVALID_PATTERN = Pattern.compile("[^\uAC00-\uD7A3a-zA-Z\uD83C-\uDBFF\uDC00-\uDFFF\u200D\uFE0F]");
 
     private final String name;
 
@@ -32,55 +35,25 @@ public class MemberName {
     private void validateName(String name) {
         validateEmpty(name);
         validateLength(name);
-        validateNumbers(name);
-        validateSpecialCharacters(name);
-        validateInvalidLanguages(name);
+        validateInvalidCharacters(name);
     }
 
-    private void validateEmpty(String memberName) {
-        if (memberName == null || memberName.isBlank()) {
+    private void validateEmpty(String name) {
+        if (name == null || name.isBlank()) {
             throw new MemberException(MemberErrorCode.MEMBER_NAME_NOT_EMPTY);
         }
     }
 
-    private void validateLength(String memberName) {
-        if (memberName.length() > MAX_LENGTH) {
+    private void validateLength(String name) {
+        if (name.length() > MAX_LENGTH) {
             throw new MemberException(MemberErrorCode.MEMBER_NAME_LENGTH_EXCEEDED);
         }
     }
 
-    private void validateNumbers(String name) {
-        if (name.chars().anyMatch(Character::isDigit)) {
-            throw new MemberException(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_NUMBERS);
+    private void validateInvalidCharacters(String name) {
+        if (INVALID_PATTERN.matcher(name).find()) {
+            throw new MemberException(MemberErrorCode.INVALID_MEMBER_NAME);
         }
-    }
-
-    private void validateSpecialCharacters(String name) {
-        if (name.chars().mapToObj(c -> (char) c).anyMatch(this::isSpecialCharacter)) {
-            throw new MemberException(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS);
-        }
-    }
-
-    private void validateInvalidLanguages(String name) {
-        if (name.chars().mapToObj(c -> (char) c).anyMatch(this::isInvalidLanguage)) {
-            throw new MemberException(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE);
-        }
-    }
-
-    private boolean isKorean(char c) {
-        return (c >= '가' && c <= '힣');
-    }
-
-    private boolean isEnglish(char c) {
-        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
-    }
-
-    private boolean isSpecialCharacter(char c) {
-        return !Character.isLetterOrDigit(c);
-    }
-
-    private boolean isInvalidLanguage(char c) {
-        return !isKorean(c) && !isEnglish(c);
     }
 
     @Override

--- a/src/test/java/org/noostak/NoostakApplicationTests.java
+++ b/src/test/java/org/noostak/NoostakApplicationTests.java
@@ -1,8 +1,10 @@
 package org.noostak;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@DisplayName("NoostakApplication 테스트")
 @SpringBootTest
 class NoostakApplicationTests {
 

--- a/src/test/java/org/noostak/member/domain/vo/AuthIdTest.java
+++ b/src/test/java/org/noostak/member/domain/vo/AuthIdTest.java
@@ -12,6 +12,7 @@ import org.noostak.member.common.MemberException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("Auth ID 테스트")
 class AuthIdTest {
 
     @Nested

--- a/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
+++ b/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
@@ -25,7 +25,8 @@ class MemberNameTest {
                 "한글이름",
                 "jsoon",
                 "영한혼합",
-                "홍길동"
+                "홍길동",
+                "😀😃😄"
         })
         void shouldCreateMemberNameSuccessfully(String validName) {
             // Given & When
@@ -44,7 +45,6 @@ class MemberNameTest {
         @DisplayName("이름이 null이거나 비어 있는 경우")
         @NullAndEmptySource
         void shouldThrowExceptionForNullOrEmptyName(String invalidName) {
-            // Given & When & Then
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NAME_NOT_EMPTY.getMessage());
@@ -57,62 +57,9 @@ class MemberNameTest {
                 "한글과영문혼합길이초과abcde"
         })
         void shouldThrowExceptionForNameLengthExceeded(String invalidName) {
-            // Given & When & Then
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NAME_LENGTH_EXCEEDED.getMessage());
-        }
-
-        @ParameterizedTest
-        @DisplayName("이름에 특수문자가 포함된 경우")
-        @CsvSource({
-                "jsoon!",
-                "jsoon@",
-                "jsoon#",
-                "jsoon$",
-                "jsoon%",
-                "jsoon^",
-                "jsoon&",
-                "jsoon*",
-                "jsoon(",
-                "jsoon)",
-                "jsoon_",
-                "jsoon+",
-                "jsoon=",
-                "jsoon|",
-                "jsoon<",
-                "jsoon>",
-                "jsoon?",
-                "jsoon{",
-                "jsoon}",
-                "jsoon[",
-                "jsoon]",
-                "jsoon~",
-                "jsoon-"
-        })
-        void shouldThrowExceptionForInvalidSpecialCharacters(String invalidName) {
-            // Given & When & Then
-            assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS.getMessage());
-        }
-
-        @ParameterizedTest
-        @DisplayName("이름에 허용되지 않은 언어(한글/영어 이외의 문자)가 포함된 경우")
-        @CsvSource({
-                "张伟",
-                "山田太郎",
-                "علي",
-                "Иван",
-                "jsoon张",
-                "こんにちは홍길동",
-                "Русский홍길동"
-        })
-        void shouldThrowExceptionForInvalidLanguages(String invalidName) {
-            // Given & When & Then
-            assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
         }
 
         @ParameterizedTest
@@ -124,45 +71,10 @@ class MemberNameTest {
                 "12jsoon"
         })
         void shouldThrowExceptionForNameContainingNumbers(String invalidName) {
-            // Given & When & Then
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_NUMBERS.getMessage());
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
         }
-
-        @ParameterizedTest
-        @DisplayName("이름에 특수문자가 포함된 경우")
-        @CsvSource({
-                "홍길동!",
-                "jsoon@",
-                "Test#jsoon",
-                "jsoon&",
-                "hello*",
-                "이름%",
-                "이름~이름",
-                "홍길동{",
-                "홍길동}",
-                "이름[",
-                "이름]",
-                "이름+",
-                "이름=",
-                "이름_",
-                "이름|",
-                "이름/",
-                "이름'",
-                "이름;",
-                "이름:",
-                "이름<",
-                "이름>",
-                "이름?",
-                "이름^"
-        })
-        void shouldThrowExceptionForNameContainingSpecialCharacters(String invalidName) {
-            assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS.getMessage());
-        }
-
 
         @ParameterizedTest
         @DisplayName("이름에 허용되지 않은 언어가 포함된 경우")
@@ -176,7 +88,6 @@ class MemberNameTest {
                 "Русский홍길동"
         })
         void shouldThrowExceptionForNameContainingInvalidLanguage(String invalidName) {
-            // Given & When & Then
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());

--- a/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
+++ b/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
@@ -8,9 +8,10 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.noostak.member.common.MemberErrorCode;
 import org.noostak.member.common.MemberException;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("멤버 이름 테스트")
 class MemberNameTest {
 
     @Nested
@@ -20,14 +21,11 @@ class MemberNameTest {
         @ParameterizedTest
         @DisplayName("유효한 이름으로 객체 생성")
         @CsvSource({
-                "Alice",
+                "jsoonworld",
                 "한글이름",
-                "JohnDoe",
+                "jsoon",
                 "영한혼합",
-                "홍길동",
-                "홍길동😊",
-                "😀홍길동",
-                "Alice😀홍길동"
+                "홍길동"
         })
         void shouldCreateMemberNameSuccessfully(String validName) {
             // Given & When
@@ -40,63 +38,148 @@ class MemberNameTest {
 
     @Nested
     @DisplayName("실패 케이스")
-    class FailureCases{
+    class FailureCases {
 
-            @ParameterizedTest
-            @DisplayName("이름이 null이거나 비어 있는 경우")
-            @NullAndEmptySource
-            void shouldThrowExceptionForNullOrEmptyName(String invalidName) {
-                // Given & When & Then
-                assertThatThrownBy(() -> MemberName.from(invalidName))
-                        .isInstanceOf(MemberException.class)
-                        .hasMessageContaining(MemberErrorCode.MEMBER_NAME_NOT_EMPTY.getMessage());
-            }
+        @ParameterizedTest
+        @DisplayName("이름이 null이거나 비어 있는 경우")
+        @NullAndEmptySource
+        void shouldThrowExceptionForNullOrEmptyName(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_NOT_EMPTY.getMessage());
+        }
 
-            @ParameterizedTest
-            @DisplayName("이름의 길이가 15자를 초과하는 경우")
-            @CsvSource({
-                    "abcdefghijklmnop",
-                    "이모지와문자가혼합된이름입니다😊😊😊😊"
-            })
-            void shouldThrowExceptionForNameLengthExceeded(String invalidName) {
-                // Given & When & Then
-                assertThatThrownBy(() -> MemberName.from(invalidName))
-                        .isInstanceOf(MemberException.class)
-                        .hasMessageContaining(MemberErrorCode.MEMBER_NAME_LENGTH_EXCEEDED.getMessage());
-            }
+        @ParameterizedTest
+        @DisplayName("이름의 길이가 15자를 초과하는 경우")
+        @CsvSource({
+                "abcdefghijklmnop",
+                "한글과영문혼합길이초과abcde"
+        })
+        void shouldThrowExceptionForNameLengthExceeded(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_LENGTH_EXCEEDED.getMessage());
+        }
 
-            @ParameterizedTest
-            @DisplayName("이름에 특수문자가 포함된 경우")
-            @CsvSource({
-                    "Alice!",
-                    "Alice@",
-                    "Alice#",
-                    "Alice$",
-                    "Alice%",
-                    "Alice^",
-                    "Alice&",
-                    "Alice*",
-                    "Alice(",
-                    "Alice)",
-                    "Alice_",
-                    "Alice+",
-                    "Alice=",
-                    "Alice|",
-                    "Alice<",
-                    "Alice>",
-                    "Alice?",
-                    "Alice{",
-                    "Alice}",
-                    "Alice[",
-                    "Alice]",
-                    "Alice~",
-                    "Alice-"
-            })
-            void shouldThrowExceptionForInvalidCharacter(String invalidName) {
-                // Given & When & Then
-                assertThatThrownBy(() -> MemberName.from(invalidName))
-                        .isInstanceOf(MemberException.class)
-                        .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_CHARACTER.getMessage());
-            }
+        @ParameterizedTest
+        @DisplayName("이름에 특수문자가 포함된 경우")
+        @CsvSource({
+                "jsoon!",
+                "jsoon@",
+                "jsoon#",
+                "jsoon$",
+                "jsoon%",
+                "jsoon^",
+                "jsoon&",
+                "jsoon*",
+                "jsoon(",
+                "jsoon)",
+                "jsoon_",
+                "jsoon+",
+                "jsoon=",
+                "jsoon|",
+                "jsoon<",
+                "jsoon>",
+                "jsoon?",
+                "jsoon{",
+                "jsoon}",
+                "jsoon[",
+                "jsoon]",
+                "jsoon~",
+                "jsoon-"
+        })
+        void shouldThrowExceptionForInvalidSpecialCharacters(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS.getMessage());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이름에 허용되지 않은 언어(한글/영어 이외의 문자)가 포함된 경우")
+        @CsvSource({
+                "张伟",
+                "山田太郎",
+                "علي",
+                "Иван",
+                "jsoon张",
+                "こんにちは홍길동",
+                "Русский홍길동"
+        })
+        void shouldThrowExceptionForInvalidLanguages(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이름에 숫자가 포함된 경우")
+        @CsvSource({
+                "홍길동1",
+                "jsoon123",
+                "Test007",
+                "12jsoon"
+        })
+        void shouldThrowExceptionForNameContainingNumbers(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_NUMBERS.getMessage());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이름에 특수문자가 포함된 경우")
+        @CsvSource({
+                "홍길동!",
+                "jsoon@",
+                "Test#jsoon",
+                "jsoon&",
+                "hello*",
+                "이름%",
+                "이름~이름",
+                "홍길동{",
+                "홍길동}",
+                "이름[",
+                "이름]",
+                "이름+",
+                "이름=",
+                "이름_",
+                "이름|",
+                "이름/",
+                "이름'",
+                "이름;",
+                "이름:",
+                "이름<",
+                "이름>",
+                "이름?",
+                "이름^"
+        })
+        void shouldThrowExceptionForNameContainingSpecialCharacters(String invalidName) {
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS.getMessage());
+        }
+
+
+        @ParameterizedTest
+        @DisplayName("이름에 허용되지 않은 언어가 포함된 경우")
+        @CsvSource({
+                "张伟",
+                "山田太郎",
+                "علي",
+                "Иван",
+                "jsoon张",
+                "こんにちは홍길동",
+                "Русский홍길동"
+        })
+        void shouldThrowExceptionForNameContainingInvalidLanguage(String invalidName) {
+            // Given & When & Then
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
+        }
     }
 }

--- a/src/test/java/org/noostak/member/domain/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/org/noostak/member/domain/vo/MemberProfileImageKeyTest.java
@@ -12,6 +12,7 @@ import org.noostak.member.common.MemberException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("멤버 프로필 이미지 키 테스트")
 class MemberProfileImageKeyTest {
 
     @Nested


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:**
  - 멤버 이름 유효성 검사 로직 개선
  - 중복된 에러 코드 정리 및 명확한 메시지 적용
  - 테스트 코드 보강 및 예외 처리 검증 추가

# 🛠️ What’s been done?
- **유효성 검사 로직 개선**
  - 멤버 이름의 최대 길이 검사를 상수(`MAX_LENGTH`)로 대체
  - 특수문자 검사 방식을 정규 표현식에서 개별 문자 검사로 변경
  - 허용되지 않은 문자(숫자, 특수문자, 한글/영어 이외 언어) 검증 로직 추가
- **에러 코드 정리**
  - 중복된 특수문자 관련 에러 코드 정리
  - 숫자 포함 여부를 검사하는 에러 코드 추가
- **테스트 코드 보강**
  - 허용되지 않은 언어 포함 여부 검사 추가
  - 특수문자 및 숫자 포함 여부를 확인하는 테스트 추가
  - 최대 길이 초과 시 이모지가 포함된 경우 테스트 추가

# 🧪 Testing Details
- **테스트 코드 및 결과**
  - `MemberNameTest`에서 다양한 입력값에 대한 예외 처리 검증
  - 특수문자 및 숫자 포함 여부를 검사하는 케이스 추가
  - 테스트 커버리지 확대 및 모든 테스트 통과 확인 ✅

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - 멤버 이름 유효성 검사 로직이 명확하고 간결한지
  - 중복된 에러 코드가 제거되었는지
  - 테스트 케이스가 충분한지
- **추가 논의 사항:**
  - 현재 방식이 최적의 유효성 검사인지 검토 필요
  - 추가적인 예외 처리 로직이 필요한지 논의
- 시간 복잡도를 O(N)으로 최적화할 수도 있었지만, 유지보수성과 가독성을 고려하여 3N으로 유지하는 것이 더 적절하다고 판단했습니다. 하나의 스트림과 루프로 처리할 수도 있지만, validate를 Set으로 관리하는 방식은 가독성과 유지보수 측면에서 복잡성이 증가할 가능성이 있다고 생각했습니다. 현재 방식이 더 명확하고 유지보수하기 쉬운 코드라고 판단했는데, 이에 대해 어떻게 생각하시나요?

# 🎯 Related Issues
- closes #21