### PR TITLE
[feat] 약속 엔티티 구현

### DIFF
--- a/src/main/java/org/noostak/appointment/common/exception/AppointmentErrorCode.java
+++ b/src/main/java/org/noostak/appointment/common/exception/AppointmentErrorCode.java
@@ -1,0 +1,38 @@
+package org.noostak.appointment.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.noostak.global.error.core.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AppointmentErrorCode implements ErrorCode {
+    APPOINTMENT_DURATION_NEGATIVE(HttpStatus.BAD_REQUEST, "약속 소요 시간은 음수가 될 수 없습니다."),
+    APPOINTMENT_DURATION_MAX(HttpStatus.BAD_REQUEST, "약속 소요 시간은 최대 1440(24시간)분을 초과할 수 없습니다."),
+    APPOINTMENT_DURATION_INVALID_UNIT(HttpStatus.BAD_REQUEST, "약속 소요 시간은 60분 단위로 입력해야 합니다."),
+
+    APPOINTMENT_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "유효하지 않은 카테고리입니다."),
+    APPOINTMENT_CATEGORY_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "약속 카테고리는 null이거나 공백일 수 없습니다."),
+
+    APPOINTMENT_MEMBER_COUNT_NEGATIVE(HttpStatus.BAD_REQUEST, "약속 멤버 수는 음수가 될 수 없습니다."),
+    APPOINTMENT_MEMBER_COUNT_MAX(HttpStatus.BAD_REQUEST, "약속 멤버 수는 최대 50명을 초과할 수 없습니다."),
+
+
+    ;
+
+    public static final String PREFIX = "[APPOINTMENT ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/org/noostak/appointment/common/exception/AppointmentException.java
+++ b/src/main/java/org/noostak/appointment/common/exception/AppointmentException.java
@@ -1,0 +1,9 @@
+package org.noostak.appointment.common.exception;
+
+import org.noostak.global.error.core.BaseException;
+
+public class AppointmentException extends BaseException {
+    public AppointmentException(AppointmentErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/noostak/appointment/domain/Appointment.java
+++ b/src/main/java/org/noostak/appointment/domain/Appointment.java
@@ -1,0 +1,52 @@
+package org.noostak.appointment.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.noostak.appointment.domain.vo.AppointmentCategory;
+import org.noostak.appointment.domain.vo.AppointmentDuration;
+import org.noostak.appointment.domain.vo.AppointmentMemberCount;
+import org.noostak.appointment.domain.vo.AppointmentStatus;
+import org.noostak.global.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Appointment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    private Group group;
+
+    private Long appointmentHostId;
+
+    @Embedded
+    @AttributeOverride(name = "count", column = @Column(name = "appointment_member_count"))
+    private AppointmentMemberCount memberCount;
+
+    @Enumerated(EnumType.STRING)
+    private AppointmentStatus appointmentStatus;
+
+    @Embedded
+    @AttributeOverride(name = "duration", column = @Column(name = "appointment_duration"))
+    private AppointmentDuration duration;
+
+    @Enumerated(EnumType.STRING)
+    private AppointmentCategory category;
+
+    private Appointment(final Long appointmentHostId, final Long duration, final String category, final AppointmentStatus appointmentStatus) {
+        this.appointmentHostId = appointmentHostId;
+        this.duration = AppointmentDuration.from(duration);
+        this.memberCount = AppointmentMemberCount.from(1L);
+        this.category = AppointmentCategory.valueOf(category);
+        this.appointmentStatus = appointmentStatus;
+    }
+
+    public static Appointment of(final Long appointmentHostId, final Long duration, final String category, final AppointmentStatus appointmentStatus) {
+        return new Appointment(appointmentHostId, duration, category, appointmentStatus);
+    }
+}

--- a/src/main/java/org/noostak/appointment/domain/vo/AppointmentCategory.java
+++ b/src/main/java/org/noostak/appointment/domain/vo/AppointmentCategory.java
@@ -1,0 +1,34 @@
+package org.noostak.appointment.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum AppointmentCategory {
+    IMPORTANT("중요"),
+    SCHEDULE("일정"),
+    HOBBY("취미"),
+    OTHER("기타");
+
+    private final String message;
+
+    public static AppointmentCategory from(String category) {
+        validateCategory(category);
+
+        return Arrays.stream(values())
+                .filter(c -> c.name().equalsIgnoreCase(category.trim()) || c.message.equals(category.trim()))
+                .findFirst()
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_CATEGORY_NOT_FOUND));
+    }
+
+    private static void validateCategory(String category) {
+        if (category == null || category.isBlank()) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_CATEGORY_NULL_OR_BLANK);
+        }
+    }
+}

--- a/src/main/java/org/noostak/appointment/domain/vo/AppointmentDuration.java
+++ b/src/main/java/org/noostak/appointment/domain/vo/AppointmentDuration.java
@@ -1,0 +1,54 @@
+package org.noostak.appointment.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+@Embeddable
+@EqualsAndHashCode
+public class AppointmentDuration {
+
+    private final Long duration;
+
+    protected AppointmentDuration() {
+        this.duration = 0L;
+    }
+
+    private AppointmentDuration(Long duration) {
+        validate(duration);
+        this.duration = duration;
+    }
+
+    public static AppointmentDuration from(Long duration) {
+        return new AppointmentDuration(duration);
+    }
+
+    public Long value() {
+        return duration;
+    }
+
+    private void validate(Long duration) {
+        validateNonNegative(duration);
+        validateMaxLimit(duration);
+        validateMultipleOfSixty(duration);
+    }
+
+    private void validateNonNegative(Long duration) {
+        if (duration < 0) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_DURATION_NEGATIVE);
+        }
+    }
+
+    private void validateMaxLimit(Long duration) {
+        if (duration > 1440) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_DURATION_MAX);
+        }
+    }
+
+    private void validateMultipleOfSixty(Long duration) {
+        if (duration % 60 != 0) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_DURATION_INVALID_UNIT);
+        }
+    }
+}

--- a/src/main/java/org/noostak/appointment/domain/vo/AppointmentMemberCount.java
+++ b/src/main/java/org/noostak/appointment/domain/vo/AppointmentMemberCount.java
@@ -1,0 +1,60 @@
+package org.noostak.appointment.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+@Embeddable
+@EqualsAndHashCode
+public class AppointmentMemberCount {
+    private static final Long MAX_MEMBERS = 50L;
+    private final Long count;
+
+    protected AppointmentMemberCount() {
+        this.count = 0L;
+    }
+
+    private AppointmentMemberCount(Long count) {
+        validateAppointmentMemberCount(count);
+        this.count = count;
+    }
+
+    public static AppointmentMemberCount from(Long count) {
+        return new AppointmentMemberCount(count);
+    }
+
+    public AppointmentMemberCount increase() {
+        return new AppointmentMemberCount(count + 1);
+    }
+
+    public AppointmentMemberCount decrease() {
+        return new AppointmentMemberCount(count - 1);
+    }
+
+    public Long value() {
+        return count;
+    }
+
+    private void validateAppointmentMemberCount(Long count) {
+        validateNonNegative(count);
+        validateMaxLimit(count);
+    }
+
+    private void validateNonNegative(Long count) {
+        if (count < 0) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_MEMBER_COUNT_NEGATIVE);
+        }
+    }
+
+    private void validateMaxLimit(Long count) {
+        if (count > MAX_MEMBERS) {
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_MEMBER_COUNT_MAX);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(count);
+    }
+}

--- a/src/main/java/org/noostak/appointment/domain/vo/AppointmentStatus.java
+++ b/src/main/java/org/noostak/appointment/domain/vo/AppointmentStatus.java
@@ -1,0 +1,13 @@
+package org.noostak.appointment.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AppointmentStatus {
+    CONFIRMED("확정"),
+    PROGRESS("진행중");
+
+    private final String message;
+}

--- a/src/test/java/org/noostak/appointment/domain/vo/AppointmentCategoryTest.java
+++ b/src/test/java/org/noostak/appointment/domain/vo/AppointmentCategoryTest.java
@@ -1,0 +1,58 @@
+package org.noostak.appointment.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppointmentCategoryTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "IMPORTANT, IMPORTANT",
+            "important, IMPORTANT",
+            "중요, IMPORTANT",
+            "SCHEDULE, SCHEDULE",
+            "schedule, SCHEDULE",
+            "일정, SCHEDULE",
+            "HOBBY, HOBBY",
+            "hobby, HOBBY",
+            "취미, HOBBY",
+            "OTHER, OTHER",
+            "other, OTHER",
+            "기타, OTHER"
+    })
+    @DisplayName("유효한 카테고리 입력에 대해 올바른 AppointmentCategory 반환")
+    void shouldReturnCorrectCategoryForValidInput(String input, AppointmentCategory expectedCategory) {
+        // When
+        AppointmentCategory category = AppointmentCategory.from(input);
+
+        // Then
+        assertThat(category).isEqualTo(expectedCategory);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"INVALID", "unknown", "wrong", "123"})
+    @DisplayName("잘못된 카테고리 입력에 대해 예외 발생")
+    void shouldThrowExceptionForInvalidCategory(String invalidCategory) {
+        // When & Then
+        assertThatThrownBy(() -> AppointmentCategory.from(invalidCategory))
+                .isInstanceOf(AppointmentException.class)
+                .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("null 또는 빈 문자열 입력에 대해 예외 발생")
+    void shouldThrowExceptionForNullOrBlankCategory(String nullOrBlankCategory) {
+        // When & Then
+        assertThatThrownBy(() -> AppointmentCategory.from(nullOrBlankCategory))
+                .isInstanceOf(AppointmentException.class)
+                .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_CATEGORY_NULL_OR_BLANK.getMessage());
+    }
+}

--- a/src/test/java/org/noostak/appointment/domain/vo/AppointmentDurationTest.java
+++ b/src/test/java/org/noostak/appointment/domain/vo/AppointmentDurationTest.java
@@ -1,0 +1,65 @@
+package org.noostak.appointment.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppointmentDurationTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @CsvSource({"0", "60", "120", "240", "1440"})
+        @DisplayName("유효한 약속 시간을 가진 객체 생성")
+        void shouldCreateWithValidDuration(Long validDuration) {
+            // When
+            AppointmentDuration duration = AppointmentDuration.from(validDuration);
+
+            // Then
+            assertThat(duration.value()).isEqualTo(validDuration);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @CsvSource({"-10", "-1"})
+        @DisplayName("약속 시간이 음수일 경우 예외 발생")
+        void shouldThrowExceptionWhenDurationIsNegative(Long invalidDuration) {
+            // When & Then
+            assertThatThrownBy(() -> AppointmentDuration.from(invalidDuration))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_DURATION_NEGATIVE.getMessage());
+        }
+
+        @ParameterizedTest
+        @CsvSource({"1441", "1500", "2000"})
+        @DisplayName("약속 시간이 1440분을 초과할 경우 예외 발생")
+        void shouldThrowExceptionWhenDurationExceedsMaxLimit(Long invalidDuration) {
+            // When & Then
+            assertThatThrownBy(() -> AppointmentDuration.from(invalidDuration))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_DURATION_MAX.getMessage());
+        }
+
+        @ParameterizedTest
+        @CsvSource({"1", "59", "125", "130", "500"})
+        @DisplayName("약속 시간이 60분 단위가 아닐 경우 예외 발생")
+        void shouldThrowExceptionWhenDurationIsNotMultipleOfSixty(Long invalidDuration) {
+            // When & Then
+            assertThatThrownBy(() -> AppointmentDuration.from(invalidDuration))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_DURATION_INVALID_UNIT.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/noostak/appointment/domain/vo/AppointmentMemberCountTest.java
+++ b/src/test/java/org/noostak/appointment/domain/vo/AppointmentMemberCountTest.java
@@ -1,0 +1,98 @@
+package org.noostak.appointment.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AppointmentMemberCountTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("초기 멤버 수가 0인 객체 생성")
+        void shouldCreateWithZeroInitialValue() {
+            // Given
+            Long initialCount = 0L;
+
+            // When
+            AppointmentMemberCount count = AppointmentMemberCount.from(initialCount);
+
+            // Then
+            assertThat(count.value()).isEqualTo(initialCount);
+        }
+
+        @Test
+        @DisplayName("멤버 수 증가")
+        void shouldIncreaseMemberCount() {
+            // Given
+            AppointmentMemberCount count = AppointmentMemberCount.from(10L);
+
+            // When
+            AppointmentMemberCount increasedCount = count.increase();
+
+            // Then
+            assertThat(increasedCount.value()).isEqualTo(11L);
+        }
+
+        @Test
+        @DisplayName("멤버 수 감소")
+        void shouldDecreaseMemberCount() {
+            // Given
+            AppointmentMemberCount count = AppointmentMemberCount.from(10L);
+
+            // When
+            AppointmentMemberCount decreasedCount = count.decrease();
+
+            // Then
+            assertThat(decreasedCount.value()).isEqualTo(9L);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("멤버 수가 음수가 될 경우 예외 발생")
+        void shouldThrowExceptionWhenCountIsNegative() {
+            // Given
+            AppointmentMemberCount count = AppointmentMemberCount.from(0L);
+
+            // When & Then
+            assertThatThrownBy(count::decrease)
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_MEMBER_COUNT_NEGATIVE.getMessage());
+        }
+
+        @Test
+        @DisplayName("멤버 수가 최대값을 초과할 경우 예외 발생")
+        void shouldThrowExceptionWhenCountExceedsMaxLimit() {
+            // Given
+            AppointmentMemberCount count = AppointmentMemberCount.from(50L);
+
+            // When & Then
+            assertThatThrownBy(count::increase)
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_MEMBER_COUNT_MAX.getMessage());
+        }
+
+        @Test
+        @DisplayName("초기값이 음수일 경우 예외 발생")
+        void shouldThrowExceptionWhenInitialValueIsNegative() {
+            // Given
+            Long initialCount = -1L;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointmentMemberCount.from(initialCount))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessageContaining(AppointmentErrorCode.APPOINTMENT_MEMBER_COUNT_NEGATIVE.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
+++ b/src/test/java/org/noostak/member/domain/vo/MemberNameTest.java
@@ -68,12 +68,12 @@ class MemberNameTest {
                 "홍길동1",
                 "jsoon123",
                 "Test007",
-                "12jsoon"
+                "12jsoon",
         })
         void shouldThrowExceptionForNameContainingNumbers(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
+                    .hasMessageContaining(MemberErrorCode.INVALID_MEMBER_NAME.getMessage());
         }
 
         @ParameterizedTest
@@ -90,7 +90,7 @@ class MemberNameTest {
         void shouldThrowExceptionForNameContainingInvalidLanguage(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(MemberException.class)
-                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID_LANGUAGE.getMessage());
+                    .hasMessageContaining(MemberErrorCode.INVALID_MEMBER_NAME.getMessage());
         }
     }
 }


### PR DESCRIPTION
### 🚀 PR 개요
- **작업 내용 요약:** 약속 엔티티를 구현하였습니다.
- **핵심 변경사항:** 약속 엔티티와 관련된 VO(Value Object)를 구현하였습니다.

### 🛠️ 주요 변경사항
- 약속 엔티티를 도메인 모델로 구현하였습니다.
- 관련 VO(`AppointmentDuration`, `AppointmentCategory`, `AppointmentMemberCount`, `AppointmentStatus`)를 추가하고, 각 VO에 대한 검증 로직을 포함하였습니다.
- VO들의 유효성 검증을 위한 테스트 코드를 작성하여, 정상 동작을 확인하였습니다.

### 🧪 테스트 상세
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약하였습니다.
  - 테스트 커버리지는 총 75%입니다.
  - 테스트 커버리지가 80%보다 낮은 이유는 `AppointmentStatus`에 대한 테스트 코드가 포함되지 않았기 때문입니다.
  - 추후 필요성을 검토한 후, 약속 상태(`AppointmentStatus`)에 대한 검증 및 테스트 코드를 추가할 예정입니다.
  - 현재까지 작성된 모든 테스트가 정상적으로 통과하였습니다.

### 👀 리뷰 시 확인할 사항
- 약속 엔티티가 필요한 필드를 모두 포함하고 있는지 확인 부탁드립니다.
- VO들의 검증 로직이 적절하게 구현되었는지 확인 부탁드립니다.

### 🎯 관련 이슈
- #22

