### PR TITLE
[feat] S3Service 기능 추가 및 upload 반환 데이터 수정

### DIFF
--- a/src/main/java/org/noostak/infra/KeyAndUrl.java
+++ b/src/main/java/org/noostak/infra/KeyAndUrl.java
@@ -1,0 +1,20 @@
+package org.noostak.infra;
+
+
+import lombok.Getter;
+
+@Getter
+public class KeyAndUrl {
+
+    private final String key;
+    private final String url;
+
+    private KeyAndUrl(String givenKey, String givenUrl) {
+        this.key = givenKey;
+        this.url = givenUrl;
+    }
+
+    public static KeyAndUrl of(String key, String url) {
+        return new KeyAndUrl(key, url);
+    }
+}

--- a/src/main/java/org/noostak/infra/S3DirectoryPath.java
+++ b/src/main/java/org/noostak/infra/S3DirectoryPath.java
@@ -1,0 +1,28 @@
+package org.noostak.infra;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3DirectoryPath {
+
+    DEFAULT("images"),
+    MEMBER("member"),
+    GROUP("group"),
+
+    ;
+
+    private final String POSTFIX = "/";
+
+    private final String name;
+
+    public String getPath() {
+        return name + POSTFIX;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/noostak/infra/S3Service.java
+++ b/src/main/java/org/noostak/infra/S3Service.java
@@ -1,28 +1,13 @@
 package org.noostak.infra;
 
-import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-@Component
-public class S3Service {
+public interface S3Service {
+    KeyAndUrl uploadImage(S3DirectoryPath dirPath, MultipartFile image) throws IOException;
 
-    private final S3Storage s3Storage;
+    String findImageUrl(String key);
 
-    private S3Service(S3Storage s3Storage) {
-        this.s3Storage = s3Storage;
-    }
-
-    public static S3Service of(S3Storage s3Storage) {
-        return new S3Service(s3Storage);
-    }
-
-    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
-        return s3Storage.upload(directoryPath, image);
-    }
-
-    public void deleteImage(String key) {
-        s3Storage.delete(key);
-    }
+    void deleteImage(String key);
 }

--- a/src/main/java/org/noostak/infra/S3ServiceImpl.java
+++ b/src/main/java/org/noostak/infra/S3ServiceImpl.java
@@ -1,0 +1,35 @@
+package org.noostak.infra;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Component
+public class S3ServiceImpl implements S3Service {
+
+    private final S3Storage s3Storage;
+
+    private S3ServiceImpl(S3Storage s3Storage) {
+        this.s3Storage = s3Storage;
+    }
+
+    public static S3ServiceImpl of(S3Storage s3Storage) {
+        return new S3ServiceImpl(s3Storage);
+    }
+
+    @Override
+    public KeyAndUrl uploadImage(S3DirectoryPath dirPath, MultipartFile image) throws IOException {
+        return s3Storage.upload(dirPath, image);
+    }
+
+    @Override
+    public String findImageUrl(String key) {
+        return s3Storage.findPublicUrlByKey(key);
+    }
+
+    @Override
+    public void deleteImage(String key) {
+        s3Storage.delete(key);
+    }
+}

--- a/src/main/java/org/noostak/infra/S3Storage.java
+++ b/src/main/java/org/noostak/infra/S3Storage.java
@@ -6,9 +6,11 @@ import software.amazon.awssdk.services.s3.S3Client;
 import java.io.IOException;
 
 public interface S3Storage {
-    String upload(String directoryPath, MultipartFile image) throws IOException;
+    KeyAndUrl upload(S3DirectoryPath fileName, MultipartFile image) throws IOException;
 
     void delete(String key);
+
+    String findPublicUrlByKey(String key);
 
     S3Client getS3Client();
 

--- a/src/main/java/org/noostak/infra/S3StorageImpl.java
+++ b/src/main/java/org/noostak/infra/S3StorageImpl.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -36,22 +37,30 @@ public class S3StorageImpl implements S3Storage {
     }
 
     @Override
-    public String upload(String directoryPath, MultipartFile image) throws IOException {
-        final String key = directoryPath + generateImageFileName();
+    public KeyAndUrl upload(S3DirectoryPath dirPath, MultipartFile image) throws IOException {
+        final String fileName = dirPath.getPath() + generateImageFileName();
 
-        validateExtension(image);
-        validateFileSize(image);
+        validateImage(image);
 
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(s3BucketName)
-                .key(key)
+                .key(fileName)
                 .contentType(image.getContentType())
                 .contentDisposition("inline")
                 .build();
 
         RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+
         s3Client.putObject(request, requestBody);
-        return key;
+
+        String publicUrl = findPublicUrlByKey(fileName);
+
+        return KeyAndUrl.of(fileName, publicUrl);
+    }
+
+    private void validateImage(MultipartFile image) {
+        validateExtension(image);
+        validateFileSize(image);
     }
 
     @Override
@@ -63,6 +72,15 @@ public class S3StorageImpl implements S3Storage {
 
         s3Client.deleteObject(deleteRequest);
     }
+
+    @Override
+    public String findPublicUrlByKey(String key) {
+        GetUrlRequest urlRequest =
+                GetUrlRequest.builder().bucket(s3BucketName).key(key).build();
+
+        return s3Client.utilities().getUrl(urlRequest).toString();
+    }
+
 
     private void validateExtension(MultipartFile image) {
         String contentType = image.getContentType();


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** S3Service에 Key를 통해 publicUrl을 가져오는 기능 추가, upload 반환 데이터 및 파라미터 수정하였습니다.
- **핵심 변경사항:** S3Service에 Key를 통해 publicUrl을 가져오는 기능 추가, upload 반환 데이터 및 파라미터 수정하였습니다.

# 🛠️ What’s been done?
- **주요 변경사항**
  - S3Service, S3Storage의 upload 관련 메소드의 파라미터를 fileName이 아닌 S3DirectoryPath를 받아오고, 로직에서 filename을 생성하도록 설정
  - S3DirectoryPath 열거형 enum 클래스 추가
  - S3Service, S3Storage에 key를 통해 url을 찾는 findPublicUrlByKey 메소드 추가
  - S3Service 구현부/인터페이스 분리
  - FakeS3StorageImpl 패키지 경로 수정

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 변경 작업 이후 테스트 모두 통과 하였습니다.
    - 이미지 업로드 성공
    - 이미지 업로드 실패
    - 이미지 삭제 성공

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  -  키 검증 관련 작업 및 예외처리는 추후 진행 하겠습니다. #50 
  - S3DirectoryPath를 파라미터로 설정하는 부분에 대한 적절성 다시 한 번 검토 부탁드립니다! 
  
# 🎯 Related Issues
- #49 
