### PR TITLE
[✨ feat] 진행 중인 약속들 조회 API 구현

### DIFF
--- a/src/main/java/org/noostak/appointment/api/AppointmentController.java
+++ b/src/main/java/org/noostak/appointment/api/AppointmentController.java
@@ -3,6 +3,7 @@ package org.noostak.appointment.api;
 import lombok.RequiredArgsConstructor;
 import org.noostak.appointment.application.AppointmentService;
 import org.noostak.appointment.dto.request.AppointmentCreateRequest;
+import org.noostak.appointment.dto.response.AppointmentRecommendedOptionsResponse;
 import org.noostak.global.success.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,13 +11,14 @@ import org.springframework.web.bind.annotation.*;
 import static org.noostak.appointment.common.success.AppointmentSuccessCode.APPOINTMENT_CREATED;
 
 @RestController
-@RequestMapping("/api/v1/groups/{groupId}/appointments")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AppointmentController {
 
     private final AppointmentService appointmentService;
 
-    @PostMapping
+    // TODO : GROUP 으로 이동
+    @PostMapping("/groups/{groupId}/appointments")
     public ResponseEntity<SuccessResponse> createAppointment(
             // @AuthenticationPrincipal Long memberId,
             @PathVariable(name = "groupId") Long groupId,
@@ -26,4 +28,14 @@ public class AppointmentController {
         appointmentService.createAppointment(memberId, groupId, request);
         return ResponseEntity.ok(SuccessResponse.of(APPOINTMENT_CREATED));
     }
+
+    @GetMapping("/appointments/{appointmentId}/recommended-options")
+    public ResponseEntity<SuccessResponse<AppointmentRecommendedOptionsResponse>> getRecommendedAppointmentOptions(
+            @PathVariable(name = "appointmentId") Long appointmentId
+    ) {
+        Long memberId = 1L;
+        AppointmentRecommendedOptionsResponse response = appointmentService.getRecommendedAppointmentOptions(memberId, appointmentId);
+        return ResponseEntity.ok(SuccessResponse.of(APPOINTMENT_CREATED, response));
+    }
+
 }

--- a/src/main/java/org/noostak/appointment/application/AppointmentService.java
+++ b/src/main/java/org/noostak/appointment/application/AppointmentService.java
@@ -1,17 +1,23 @@
 package org.noostak.appointment.application;
 
 import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.create.AppointmentCreateService;
+import org.noostak.appointment.application.recommendation.AppointmentRecommendedOptionService;
 import org.noostak.appointment.dto.request.AppointmentCreateRequest;
-import org.noostak.appointmentoption.application.AppointmentOptionConfirmService;
+import org.noostak.appointment.dto.response.AppointmentRecommendedOptionsResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AppointmentService {
     private final AppointmentCreateService appointmentCreateService;
-    private final AppointmentOptionConfirmService appointmentConfirmService;
+    private final AppointmentRecommendedOptionService appointmentRecommendedOptionService;
 
     public void createAppointment(Long memberId, Long groupId, AppointmentCreateRequest request) {
         appointmentCreateService.createAppointment(memberId, groupId, request);
+    }
+
+    public AppointmentRecommendedOptionsResponse getRecommendedAppointmentOptions(Long memberId, Long appointmentId) {
+        return appointmentRecommendedOptionService.getRecommendedAppointmentOptions(memberId, appointmentId);
     }
 }

--- a/src/main/java/org/noostak/appointment/application/create/AppointmentCreateService.java
+++ b/src/main/java/org/noostak/appointment/application/create/AppointmentCreateService.java
@@ -1,4 +1,4 @@
-package org.noostak.appointment.application;
+package org.noostak.appointment.application.create;
 
 import org.noostak.appointment.dto.request.AppointmentCreateRequest;
 

--- a/src/main/java/org/noostak/appointment/application/create/AppointmentCreateServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/create/AppointmentCreateServiceImpl.java
@@ -1,4 +1,4 @@
-package org.noostak.appointment.application;
+package org.noostak.appointment.application.create;
 
 import lombok.RequiredArgsConstructor;
 import org.noostak.appointment.common.exception.AppointmentErrorCode;

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryService.java
@@ -1,41 +1,9 @@
 package org.noostak.appointment.application.recommendation;
 
-import lombok.RequiredArgsConstructor;
-import org.noostak.appointment.common.exception.AppointmentErrorCode;
-import org.noostak.appointment.common.exception.AppointmentException;
-import org.noostak.appointment.domain.AppointmentHostSelectionTime;
-import org.noostak.appointment.domain.AppointmentHostSelectionTimeRepository;
 import org.noostak.appointment.util.TimeSlot;
-import org.noostak.appointment.util.AppointmentTimeSplitter;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class AppointmentHostSelectedTimeQueryService {
-    private final AppointmentHostSelectionTimeRepository hostSelectionTimeRepository;
-
-    public List<TimeSlot> splitHostSelectedTimeSlots(Long appointmentId, Long durationInMinutes) {
-        List<AppointmentHostSelectionTime> selectedTimes = findSelectedTimes(appointmentId);
-        return selectedTimes.stream()
-                .flatMap(selectionTime -> splitTimeSlotsFromSelectionTime(selectionTime, durationInMinutes).stream())
-                .toList();
-    }
-
-    private List<AppointmentHostSelectionTime> findSelectedTimes(Long appointmentId) {
-        List<AppointmentHostSelectionTime> selectedTimes = hostSelectionTimeRepository.findByAppointmentId(appointmentId);
-        if (selectedTimes.isEmpty()) {
-            throw new AppointmentException(AppointmentErrorCode.HOST_SELECTION_TIME_NOT_FOUND);
-        }
-        return selectedTimes;
-    }
-
-    private List<TimeSlot> splitTimeSlotsFromSelectionTime(AppointmentHostSelectionTime selectionTime, Long durationInMinutes) {
-        LocalDateTime date = selectionTime.getStartTime().toLocalDate().atStartOfDay();
-        return AppointmentTimeSplitter.splitTimeSlots(date, selectionTime.getStartTime(), selectionTime.getEndTime(), durationInMinutes.intValue());
-    }
+public interface AppointmentHostSelectedTimeQueryService {
+    List<TimeSlot> splitHostSelectedTimeSlots(Long appointmentId, Long durationInMinutes);
 }

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryService.java
@@ -1,0 +1,41 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.AppointmentHostSelectionTime;
+import org.noostak.appointment.domain.AppointmentHostSelectionTimeRepository;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.appointment.util.AppointmentTimeSplitter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentHostSelectedTimeQueryService {
+    private final AppointmentHostSelectionTimeRepository hostSelectionTimeRepository;
+
+    public List<TimeSlot> splitHostSelectedTimeSlots(Long appointmentId, Long durationInMinutes) {
+        List<AppointmentHostSelectionTime> selectedTimes = findSelectedTimes(appointmentId);
+        return selectedTimes.stream()
+                .flatMap(selectionTime -> splitTimeSlotsFromSelectionTime(selectionTime, durationInMinutes).stream())
+                .toList();
+    }
+
+    private List<AppointmentHostSelectionTime> findSelectedTimes(Long appointmentId) {
+        List<AppointmentHostSelectionTime> selectedTimes = hostSelectionTimeRepository.findByAppointmentId(appointmentId);
+        if (selectedTimes.isEmpty()) {
+            throw new AppointmentException(AppointmentErrorCode.HOST_SELECTION_TIME_NOT_FOUND);
+        }
+        return selectedTimes;
+    }
+
+    private List<TimeSlot> splitTimeSlotsFromSelectionTime(AppointmentHostSelectionTime selectionTime, Long durationInMinutes) {
+        LocalDateTime date = selectionTime.getStartTime().toLocalDate().atStartOfDay();
+        return AppointmentTimeSplitter.splitTimeSlots(date, selectionTime.getStartTime(), selectionTime.getEndTime(), durationInMinutes.intValue());
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryService.java
@@ -1,32 +1,10 @@
 package org.noostak.appointment.application.recommendation;
 
-import lombok.RequiredArgsConstructor;
-import org.noostak.appointment.common.exception.AppointmentErrorCode;
-import org.noostak.appointment.common.exception.AppointmentException;
 import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
-import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class AppointmentMemberAvailabilityQueryService {
-    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
-
-    public Map<Long, List<AppointmentMemberAvailableTime>> findAvailableTimeSlotsByAppointmentId(Long appointmentId) {
-        List<AppointmentMemberAvailableTime> availableTimes = availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId);
-
-        if (availableTimes.isEmpty()) {
-            throw new AppointmentException(AppointmentErrorCode.MEMBER_AVAILABILITY_NOT_FOUND);
-        }
-
-        return availableTimes.stream()
-                .collect(Collectors.groupingBy(time -> time.getAppointmentMember().getId()));
-    }
+public interface AppointmentMemberAvailabilityQueryService {
+    Map<Long, List<AppointmentMemberAvailableTime>> findAvailableTimeSlotsByAppointmentId(Long appointmentId);
 }
-

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryService.java
@@ -1,0 +1,32 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentMemberAvailabilityQueryService {
+    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
+
+    public Map<Long, List<AppointmentMemberAvailableTime>> findAvailableTimeSlotsByAppointmentId(Long appointmentId) {
+        List<AppointmentMemberAvailableTime> availableTimes = availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId);
+
+        if (availableTimes.isEmpty()) {
+            throw new AppointmentException(AppointmentErrorCode.MEMBER_AVAILABILITY_NOT_FOUND);
+        }
+
+        return availableTimes.stream()
+                .collect(Collectors.groupingBy(time -> time.getAppointmentMember().getId()));
+    }
+}
+

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandService.java
@@ -1,26 +1,11 @@
 package org.noostak.appointment.application.recommendation;
 
-import lombok.RequiredArgsConstructor;
 import org.noostak.appointment.domain.Appointment;
 import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
 import org.noostak.appointmentoption.domain.AppointmentOption;
-import org.noostak.appointmentoption.domain.AppointmentOptionRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-public class AppointmentOptionCommandService {
-    private final AppointmentOptionRepository appointmentOptionRepository;
-
-    @Transactional
-    public List<AppointmentOption> saveOptions(Appointment appointment, List<AppointmentOptionAvailabilityResponse> options) {
-        return options.stream()
-                .map(dto -> appointmentOptionRepository.save(
-                        AppointmentOption.of(appointment, dto.date(), dto.startTime(), dto.endTime())))
-                .toList();
-    }
+public interface AppointmentOptionCommandService {
+    List<AppointmentOption> saveOptions(Appointment appointment, List<AppointmentOptionAvailabilityResponse> options);
 }
-

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandService.java
@@ -1,0 +1,26 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentoption.domain.AppointmentOptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AppointmentOptionCommandService {
+    private final AppointmentOptionRepository appointmentOptionRepository;
+
+    @Transactional
+    public List<AppointmentOption> saveOptions(Appointment appointment, List<AppointmentOptionAvailabilityResponse> options) {
+        return options.stream()
+                .map(dto -> appointmentOptionRepository.save(
+                        AppointmentOption.of(appointment, dto.date(), dto.startTime(), dto.endTime())))
+                .toList();
+    }
+}
+

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityService.java
@@ -1,77 +1,16 @@
 package org.noostak.appointment.application.recommendation;
 
-import lombok.RequiredArgsConstructor;
-import org.noostak.appointment.util.TimeSlot;
 import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
-import org.noostak.appointment.util.AppointmentAvailabilityMatcher;
-import org.noostak.appointment.util.AppointmentOptionResponseMapper;
 import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
 import org.noostak.appointmentoption.domain.AppointmentOption;
-import org.noostak.group.domain.GroupRepository;
-import org.noostak.likes.domain.LikeRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class AppointmentOptionPriorityService {
-
-    private final LikeRepository likeRepository;
-    private final GroupRepository groupRepository;
-
-    public List<AppointmentPriorityGroupResponse> determineOptionPriority(
+public interface AppointmentOptionPriorityService {
+    List<AppointmentPriorityGroupResponse> determineOptionPriority(
             List<AppointmentOption> sortedOptions, Long memberId,
             Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
             Map<Long, String> memberNames
-    ) {
-        Map<AppointmentOption, Long> availabilityCountMap = calculateAvailabilityCount(sortedOptions, memberAvailability);
-
-        Map<Long, List<AppointmentOption>> groupedOptions = categorizeOptionsByPriority(availabilityCountMap);
-
-        return mapToPriorityGroups(groupedOptions, memberId, memberAvailability, memberNames);
-    }
-
-    private Map<AppointmentOption, Long> calculateAvailabilityCount(
-            List<AppointmentOption> options,
-            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
-    ) {
-        return options.stream()
-                .collect(Collectors.toMap(
-                        option -> option,
-                        option -> (long) AppointmentAvailabilityMatcher.getAvailableMembers(
-                                        TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime()), memberAvailability)
-                                .size()
-                ));
-    }
-
-    private Map<Long, List<AppointmentOption>> categorizeOptionsByPriority(
-            Map<AppointmentOption, Long> availabilityMap
-    ) {
-        return availabilityMap.entrySet().stream()
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getValue,
-                        Collectors.mapping(Map.Entry::getKey, Collectors.toList())
-                ));
-    }
-
-    private List<AppointmentPriorityGroupResponse> mapToPriorityGroups(
-            Map<Long, List<AppointmentOption>> groupedOptions,
-            Long memberId,
-            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
-            Map<Long, String> memberNames
-    ) {
-        return groupedOptions.entrySet().stream()
-                .map(entry -> AppointmentPriorityGroupResponse.of(entry.getKey(),
-                        entry.getValue().stream()
-                                .map(option -> AppointmentOptionResponseMapper.toResponse(
-                                        option, memberId, memberAvailability, memberNames, likeRepository, groupRepository))
-                                .toList()))
-                .sorted((a, b) -> Long.compare(a.priority(), b.priority()))
-                .toList();
-    }
+    );
 }

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityService.java
@@ -1,0 +1,77 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
+import org.noostak.appointment.util.AppointmentAvailabilityMatcher;
+import org.noostak.appointment.util.AppointmentOptionResponseMapper;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.group.domain.GroupRepository;
+import org.noostak.likes.domain.LikeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentOptionPriorityService {
+
+    private final LikeRepository likeRepository;
+    private final GroupRepository groupRepository;
+
+    public List<AppointmentPriorityGroupResponse> determineOptionPriority(
+            List<AppointmentOption> sortedOptions, Long memberId,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            Map<Long, String> memberNames
+    ) {
+        Map<AppointmentOption, Long> availabilityCountMap = calculateAvailabilityCount(sortedOptions, memberAvailability);
+
+        Map<Long, List<AppointmentOption>> groupedOptions = categorizeOptionsByPriority(availabilityCountMap);
+
+        return mapToPriorityGroups(groupedOptions, memberId, memberAvailability, memberNames);
+    }
+
+    private Map<AppointmentOption, Long> calculateAvailabilityCount(
+            List<AppointmentOption> options,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        return options.stream()
+                .collect(Collectors.toMap(
+                        option -> option,
+                        option -> (long) AppointmentAvailabilityMatcher.getAvailableMembers(
+                                        TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime()), memberAvailability)
+                                .size()
+                ));
+    }
+
+    private Map<Long, List<AppointmentOption>> categorizeOptionsByPriority(
+            Map<AppointmentOption, Long> availabilityMap
+    ) {
+        return availabilityMap.entrySet().stream()
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getValue,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toList())
+                ));
+    }
+
+    private List<AppointmentPriorityGroupResponse> mapToPriorityGroups(
+            Map<Long, List<AppointmentOption>> groupedOptions,
+            Long memberId,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            Map<Long, String> memberNames
+    ) {
+        return groupedOptions.entrySet().stream()
+                .map(entry -> AppointmentPriorityGroupResponse.of(entry.getKey(),
+                        entry.getValue().stream()
+                                .map(option -> AppointmentOptionResponseMapper.toResponse(
+                                        option, memberId, memberAvailability, memberNames, likeRepository, groupRepository))
+                                .toList()))
+                .sorted((a, b) -> Long.compare(a.priority(), b.priority()))
+                .toList();
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryService.java
@@ -1,27 +1,7 @@
 package org.noostak.appointment.application.recommendation;
 
-import lombok.RequiredArgsConstructor;
-import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
-import org.noostak.member.domain.Member;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class AppointmentParticipantQueryService {
-    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
-
-    public Map<Long, String> findParticipantNamesByAppointmentId(Long appointmentId) {
-        return availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId).stream()
-                .map(memberTime -> memberTime.getAppointmentMember().getMember())
-                .collect(Collectors.toMap(
-                        Member::getId,
-                        member -> member.getName().value(),
-                        (existing, duplicate) -> existing
-                ));
-    }
+public interface AppointmentParticipantQueryService {
+    Map<Long, String> findParticipantNamesByAppointmentId(Long appointmentId);
 }

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryService.java
@@ -1,0 +1,27 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
+import org.noostak.member.domain.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentParticipantQueryService {
+    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
+
+    public Map<Long, String> findParticipantNamesByAppointmentId(Long appointmentId) {
+        return availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId).stream()
+                .map(memberTime -> memberTime.getAppointmentMember().getMember())
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        member -> member.getName().value(),
+                        (existing, duplicate) -> existing
+                ));
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendationFacade.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendationFacade.java
@@ -31,9 +31,9 @@ public class AppointmentRecommendationFacade {
 
         Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability = appointmentMemberAvailabilityQueryService.findAvailableTimeSlotsByAppointmentId(appointmentId);
 
-        List<AppointmentOptionAvailabilityResponse> optionDTOs = AppointmentAvailabilityMatcher.matchAvailability(timeSlots, memberAvailability);
+        List<AppointmentOptionAvailabilityResponse> options = AppointmentAvailabilityMatcher.matchAvailability(timeSlots, memberAvailability);
 
-        List<AppointmentOption> savedOptions = appointmentOptionCommandService.saveOptions(appointment, optionDTOs);
+        List<AppointmentOption> savedOptions = appointmentOptionCommandService.saveOptions(appointment, options);
 
         List<AppointmentOption> sortedOptions = AppointmentOptionSorter.sortAndFilterOptions(savedOptions, memberAvailability);
 

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendationFacade.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendationFacade.java
@@ -1,0 +1,44 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
+import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
+import org.noostak.appointment.util.AppointmentAvailabilityMatcher;
+import org.noostak.appointment.util.AppointmentOptionSorter;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentRecommendationFacade {
+
+    private final AppointmentHostSelectedTimeQueryService appointmentHostSelectedTimeQueryService;
+    private final AppointmentMemberAvailabilityQueryService appointmentMemberAvailabilityQueryService;
+    private final AppointmentOptionCommandService appointmentOptionCommandService;
+    private final AppointmentParticipantQueryService appointmentParticipantQueryService;
+    private final AppointmentOptionPriorityService optionPriorityService;
+
+    public List<AppointmentPriorityGroupResponse> getRecommendedOptions(Long memberId, Long appointmentId, Appointment appointment) {
+        List<TimeSlot> timeSlots = appointmentHostSelectedTimeQueryService.splitHostSelectedTimeSlots(appointmentId, 60L);
+
+        Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability = appointmentMemberAvailabilityQueryService.findAvailableTimeSlotsByAppointmentId(appointmentId);
+
+        List<AppointmentOptionAvailabilityResponse> optionDTOs = AppointmentAvailabilityMatcher.matchAvailability(timeSlots, memberAvailability);
+
+        List<AppointmentOption> savedOptions = appointmentOptionCommandService.saveOptions(appointment, optionDTOs);
+
+        List<AppointmentOption> sortedOptions = AppointmentOptionSorter.sortAndFilterOptions(savedOptions, memberAvailability);
+
+        Map<Long, String> memberNames = appointmentParticipantQueryService.findParticipantNamesByAppointmentId(appointmentId);
+
+        return optionPriorityService.determineOptionPriority(sortedOptions, memberId, memberAvailability, memberNames);
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendedOptionService.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendedOptionService.java
@@ -1,0 +1,7 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.noostak.appointment.dto.response.AppointmentRecommendedOptionsResponse;
+
+public interface AppointmentRecommendedOptionService {
+    AppointmentRecommendedOptionsResponse getRecommendedAppointmentOptions(Long memberId, Long appointmentId);
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendedOptionServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/AppointmentRecommendedOptionServiceImpl.java
@@ -1,0 +1,35 @@
+package org.noostak.appointment.application.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.domain.AppointmentRepository;
+import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
+import org.noostak.appointment.dto.response.AppointmentRecommendedOptionsResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentRecommendedOptionServiceImpl implements AppointmentRecommendedOptionService {
+
+    private final AppointmentRepository appointmentRepository;
+    private final AppointmentRecommendationFacade recommendationFacade;
+
+    @Override
+    @Transactional
+    public AppointmentRecommendedOptionsResponse getRecommendedAppointmentOptions(Long memberId, Long appointmentId) {
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_NOT_FOUND));
+
+        boolean isAppointmentHost = appointment.getAppointmentHostId().equals(memberId);
+
+        List<AppointmentPriorityGroupResponse> priorityGroups = recommendationFacade.getRecommendedOptions(memberId, appointmentId, appointment);
+
+        return AppointmentRecommendedOptionsResponse.of(isAppointmentHost, priorityGroups);
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentHostSelectedTimeQueryServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentHostSelectedTimeQueryServiceImpl.java
@@ -1,0 +1,43 @@
+package org.noostak.appointment.application.recommendation.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentHostSelectedTimeQueryService;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.AppointmentHostSelectionTime;
+import org.noostak.appointment.domain.AppointmentHostSelectionTimeRepository;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.appointment.util.AppointmentTimeSplitter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentHostSelectedTimeQueryServiceImpl implements AppointmentHostSelectedTimeQueryService {
+    private final AppointmentHostSelectionTimeRepository hostSelectionTimeRepository;
+
+    @Override
+    public List<TimeSlot> splitHostSelectedTimeSlots(Long appointmentId, Long durationInMinutes) {
+        List<AppointmentHostSelectionTime> selectedTimes = findSelectedTimes(appointmentId);
+        return selectedTimes.stream()
+                .flatMap(selectionTime -> splitTimeSlotsFromSelectionTime(selectionTime, durationInMinutes).stream())
+                .toList();
+    }
+
+    private List<AppointmentHostSelectionTime> findSelectedTimes(Long appointmentId) {
+        List<AppointmentHostSelectionTime> selectedTimes = hostSelectionTimeRepository.findByAppointmentId(appointmentId);
+        if (selectedTimes.isEmpty()) {
+            throw new AppointmentException(AppointmentErrorCode.HOST_SELECTION_TIME_NOT_FOUND);
+        }
+        return selectedTimes;
+    }
+
+    private List<TimeSlot> splitTimeSlotsFromSelectionTime(AppointmentHostSelectionTime selectionTime, Long durationInMinutes) {
+        LocalDateTime date = selectionTime.getStartTime().toLocalDate().atStartOfDay();
+        return AppointmentTimeSplitter.splitTimeSlots(date, selectionTime.getStartTime(), selectionTime.getEndTime(), durationInMinutes.intValue());
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentMemberAvailabilityQueryServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentMemberAvailabilityQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package org.noostak.appointment.application.recommendation.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentMemberAvailabilityQueryService;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentMemberAvailabilityQueryServiceImpl implements AppointmentMemberAvailabilityQueryService {
+    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
+
+    @Override
+    public Map<Long, List<AppointmentMemberAvailableTime>> findAvailableTimeSlotsByAppointmentId(Long appointmentId) {
+        List<AppointmentMemberAvailableTime> availableTimes = availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId);
+
+        if (availableTimes.isEmpty()) {
+            throw new AppointmentException(AppointmentErrorCode.MEMBER_AVAILABILITY_NOT_FOUND);
+        }
+
+        return availableTimes.stream()
+                .collect(Collectors.groupingBy(time -> time.getAppointmentMember().getId()));
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionCommandServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionCommandServiceImpl.java
@@ -1,0 +1,27 @@
+package org.noostak.appointment.application.recommendation.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentOptionCommandService;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentoption.domain.AppointmentOptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AppointmentOptionCommandServiceImpl implements AppointmentOptionCommandService {
+    private final AppointmentOptionRepository appointmentOptionRepository;
+
+    @Override
+    @Transactional
+    public List<AppointmentOption> saveOptions(Appointment appointment, List<AppointmentOptionAvailabilityResponse> options) {
+        return options.stream()
+                .map(dto -> appointmentOptionRepository.save(
+                        AppointmentOption.of(appointment, dto.date(), dto.startTime(), dto.endTime())))
+                .toList();
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionPriorityServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionPriorityServiceImpl.java
@@ -1,0 +1,79 @@
+package org.noostak.appointment.application.recommendation.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentOptionPriorityService;
+import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.appointment.util.AppointmentAvailabilityMatcher;
+import org.noostak.appointment.util.AppointmentOptionResponseMapper;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.group.domain.GroupRepository;
+import org.noostak.likes.domain.LikeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentOptionPriorityServiceImpl implements AppointmentOptionPriorityService {
+
+    private final LikeRepository likeRepository;
+    private final GroupRepository groupRepository;
+
+    @Override
+    public List<AppointmentPriorityGroupResponse> determineOptionPriority(
+            List<AppointmentOption> sortedOptions, Long memberId,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            Map<Long, String> memberNames
+    ) {
+        Map<AppointmentOption, Long> availabilityCountMap = calculateAvailabilityCount(sortedOptions, memberAvailability);
+
+        Map<Long, List<AppointmentOption>> groupedOptions = categorizeOptionsByPriority(availabilityCountMap);
+
+        return mapToPriorityGroups(groupedOptions, memberId, memberAvailability, memberNames);
+    }
+
+    private Map<AppointmentOption, Long> calculateAvailabilityCount(
+            List<AppointmentOption> options,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        return options.stream()
+                .collect(Collectors.toMap(
+                        option -> option,
+                        option -> (long) AppointmentAvailabilityMatcher.getAvailableMembers(
+                                        TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime()), memberAvailability)
+                                .size()
+                ));
+    }
+
+    private Map<Long, List<AppointmentOption>> categorizeOptionsByPriority(
+            Map<AppointmentOption, Long> availabilityMap
+    ) {
+        return availabilityMap.entrySet().stream()
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getValue,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toList())
+                ));
+    }
+
+    private List<AppointmentPriorityGroupResponse> mapToPriorityGroups(
+            Map<Long, List<AppointmentOption>> groupedOptions,
+            Long memberId,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            Map<Long, String> memberNames
+    ) {
+        return groupedOptions.entrySet().stream()
+                .map(entry -> AppointmentPriorityGroupResponse.of(entry.getKey(),
+                        entry.getValue().stream()
+                                .map(option -> AppointmentOptionResponseMapper.toResponse(
+                                        option, memberId, memberAvailability, memberNames, likeRepository, groupRepository))
+                                .toList()))
+                .sorted((a, b) -> Long.compare(a.priority(), b.priority()))
+                .toList();
+    }
+}

--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentParticipantQueryServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentParticipantQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package org.noostak.appointment.application.recommendation.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentParticipantQueryService;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
+import org.noostak.member.domain.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentParticipantQueryServiceImpl implements AppointmentParticipantQueryService {
+    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
+
+    @Override
+    public Map<Long, String> findParticipantNamesByAppointmentId(Long appointmentId) {
+        return availableTimesRepository.findByAppointmentMember_AppointmentId(appointmentId).stream()
+                .map(memberTime -> memberTime.getAppointmentMember().getMember())
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        member -> member.getName().value(),
+                        (existing, duplicate) -> existing
+                ));
+    }
+}

--- a/src/main/java/org/noostak/appointment/common/exception/AppointmentErrorCode.java
+++ b/src/main/java/org/noostak/appointment/common/exception/AppointmentErrorCode.java
@@ -28,6 +28,9 @@ public enum AppointmentErrorCode implements ErrorCode {
     INVALID_APPOINTMENT_NAME_CHARACTER(HttpStatus.BAD_REQUEST, "약속 이름은 한글, 영어, 숫자, 공백만 허용됩니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 멤버를 찾을 수 없습니다."),
+    HOST_SELECTION_TIME_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 약속의 호스트 선택 시간을 찾을 수 없습니다."),
+    MEMBER_AVAILABILITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 약속의 멤버 가용 시간을 찾을 수 없습니다."),
+    INVALID_DURATION(HttpStatus.BAD_REQUEST, "유효하지 않은 소요 시간입니다."),
     ;
 
     public static final String PREFIX = "[APPOINTMENT ERROR] ";

--- a/src/main/java/org/noostak/appointment/domain/AppointmentRepository.java
+++ b/src/main/java/org/noostak/appointment/domain/AppointmentRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
+public interface AppointmentRepository extends JpaRepository<Appointment, Long>, AppointmentRepositoryCustom {
 }

--- a/src/main/java/org/noostak/appointment/domain/AppointmentRepositoryCustom.java
+++ b/src/main/java/org/noostak/appointment/domain/AppointmentRepositoryCustom.java
@@ -1,0 +1,7 @@
+package org.noostak.appointment.domain;
+
+import java.util.List;
+
+public interface AppointmentRepositoryCustom {
+    List<Appointment> findAllByGroupId(Long groupId);
+}

--- a/src/main/java/org/noostak/appointment/domain/AppointmentRepositoryImpl.java
+++ b/src/main/java/org/noostak/appointment/domain/AppointmentRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.noostak.appointment.domain;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+
+import static org.noostak.appointment.domain.QAppointment.appointment;
+
+@RequiredArgsConstructor
+public class AppointmentRepositoryImpl implements AppointmentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Appointment> findAllByGroupId(Long groupId) {
+        return queryFactory
+                .selectFrom(appointment)
+                .where(appointment.group.id.eq(groupId))
+                .orderBy(appointment.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentMyInfoResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentMyInfoResponse.java
@@ -1,0 +1,11 @@
+package org.noostak.appointment.dto.response;
+
+public record AppointmentMyInfoResponse(
+        String availability,
+        Long position,
+        String name
+) {
+    public static AppointmentMyInfoResponse of(String availability, Long position, String name) {
+        return new AppointmentMyInfoResponse(availability, position, name);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionAvailabilityResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionAvailabilityResponse.java
@@ -1,0 +1,15 @@
+package org.noostak.appointment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AppointmentOptionAvailabilityResponse(
+        LocalDateTime date,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        List<Long> availableMembers
+) {
+    public static AppointmentOptionAvailabilityResponse of(LocalDateTime date, LocalDateTime startTime, LocalDateTime endTime, List<Long> availableMembers) {
+        return new AppointmentOptionAvailabilityResponse(date, startTime, endTime, availableMembers);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionResponse.java
@@ -1,0 +1,21 @@
+package org.noostak.appointment.dto.response;
+
+public record AppointmentOptionResponse(
+        Long optionId,
+        Long likes,
+        boolean liked,
+        Long groupMemberCount,
+        Long availableMemberCount,
+        AppointmentOptionTimeResponse appointmentOptionTime,
+        AppointmentMyInfoResponse myInfo,
+        AvailableFriendsResponse availableFriends,
+        UnavailableFriendsResponse unavailableFriends
+) {
+    public static AppointmentOptionResponse of(
+            Long optionId, Long likes, boolean liked, Long groupMemberCount, Long availableMemberCount,
+            AppointmentOptionTimeResponse appointmentOptionTime, AppointmentMyInfoResponse myInfo,
+            AvailableFriendsResponse availableFriends, UnavailableFriendsResponse unavailableFriends) {
+        return new AppointmentOptionResponse(optionId, likes, liked, groupMemberCount, availableMemberCount,
+                appointmentOptionTime, myInfo, availableFriends, unavailableFriends);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionTimeResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentOptionTimeResponse.java
@@ -1,0 +1,13 @@
+package org.noostak.appointment.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AppointmentOptionTimeResponse(
+        LocalDateTime date,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+    public static AppointmentOptionTimeResponse of(LocalDateTime date, LocalDateTime startTime, LocalDateTime endTime) {
+        return new AppointmentOptionTimeResponse(date, startTime, endTime);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentPriorityGroupResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentPriorityGroupResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointment.dto.response;
+
+import java.util.List;
+
+public record AppointmentPriorityGroupResponse(
+        Long priority,
+        List<AppointmentOptionResponse> options
+) {
+    public static AppointmentPriorityGroupResponse of(Long priority, List<AppointmentOptionResponse> options) {
+        return new AppointmentPriorityGroupResponse(priority, options);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AppointmentRecommendedOptionsResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AppointmentRecommendedOptionsResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointment.dto.response;
+
+import java.util.List;
+
+public record AppointmentRecommendedOptionsResponse(
+        boolean isAppointmentHost,
+        List<AppointmentPriorityGroupResponse> priorities
+) {
+    public static AppointmentRecommendedOptionsResponse of(boolean isAppointmentHost, List<AppointmentPriorityGroupResponse> priorities) {
+        return new AppointmentRecommendedOptionsResponse(isAppointmentHost, priorities);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/AvailableFriendsResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/AvailableFriendsResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointment.dto.response;
+
+import java.util.List;
+
+public record AvailableFriendsResponse(
+        Long count,
+        List<String> names
+) {
+    public static AvailableFriendsResponse of(Long count, List<String> names) {
+        return new AvailableFriendsResponse(count, names);
+    }
+}

--- a/src/main/java/org/noostak/appointment/dto/response/UnavailableFriendsResponse.java
+++ b/src/main/java/org/noostak/appointment/dto/response/UnavailableFriendsResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointment.dto.response;
+
+import java.util.List;
+
+public record UnavailableFriendsResponse(
+        Long count,
+        List<String> names
+) {
+    public static UnavailableFriendsResponse of(Long count, List<String> names) {
+        return new UnavailableFriendsResponse(count, names);
+    }
+}

--- a/src/main/java/org/noostak/appointment/util/AppointmentAvailabilityMatcher.java
+++ b/src/main/java/org/noostak/appointment/util/AppointmentAvailabilityMatcher.java
@@ -1,0 +1,35 @@
+package org.noostak.appointment.util;
+
+import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+
+import java.util.List;
+import java.util.Map;
+
+public class AppointmentAvailabilityMatcher {
+
+    public static List<AppointmentOptionAvailabilityResponse> matchAvailability(
+            List<TimeSlot> timeSlots,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        return timeSlots.stream()
+                .map(slot -> {
+                    List<Long> availableMembers = getAvailableMembers(slot, memberAvailability);
+
+                    return AppointmentOptionAvailabilityResponse.of(slot.date(), slot.start(), slot.end(), availableMembers);
+                })
+                .toList();
+    }
+
+    public static List<Long> getAvailableMembers(TimeSlot slot, Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability) {
+        return memberAvailability.entrySet().stream()
+                .filter(entry -> satisfiesDuration(entry.getValue(), slot))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    public static boolean satisfiesDuration(List<AppointmentMemberAvailableTime> memberTimes, TimeSlot slot) {
+        return memberTimes.stream()
+                .anyMatch(time -> !time.getStartTime().isAfter(slot.start()) && !time.getEndTime().isBefore(slot.end()));
+    }
+}

--- a/src/main/java/org/noostak/appointment/util/AppointmentOptionResponseMapper.java
+++ b/src/main/java/org/noostak/appointment/util/AppointmentOptionResponseMapper.java
@@ -1,0 +1,136 @@
+package org.noostak.appointment.util;
+
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.dto.response.*;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.group.domain.GroupRepository;
+import org.noostak.likes.domain.LikeRepository;
+
+import java.util.List;
+import java.util.Map;
+
+public class AppointmentOptionResponseMapper {
+
+    public static AppointmentOptionResponse toResponse(
+            AppointmentOption option,
+            Long memberId,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            Map<Long, String> memberNames,
+            LikeRepository likeRepository,
+            GroupRepository groupRepository
+    ) {
+        List<Long> availableMembers = findAvailableMembers(option, memberAvailability);
+        List<Long> unavailableMembers = findUnavailableMembers(memberAvailability, availableMembers);
+        String myName = findMemberName(memberId, memberNames);
+        boolean isAvailable = availableMembers.contains(memberId);
+        Long position = findMemberPosition(isAvailable, memberId, availableMembers, unavailableMembers);
+        String availability = determineAvailability(isAvailable);
+
+        return createAppointmentOptionResponse(
+                option, memberId, availableMembers, unavailableMembers,
+                availability, position, myName,
+                likeRepository, groupRepository,
+                memberNames
+        );
+    }
+
+
+    private static List<Long> findAvailableMembers(
+            AppointmentOption option,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        return memberAvailability.entrySet().stream()
+                .filter(entry -> AppointmentAvailabilityMatcher.satisfiesDuration(
+                        entry.getValue(),
+                        TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime())
+                ))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private static List<Long> findUnavailableMembers(
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
+            List<Long> availableMembers
+    ) {
+        return memberAvailability.keySet().stream()
+                .filter(id -> !availableMembers.contains(id))
+                .toList();
+    }
+
+    private static Long findMemberPosition(
+            boolean isAvailable,
+            Long memberId,
+            List<Long> availableMembers,
+            List<Long> unavailableMembers
+    ) {
+        if (isAvailable) {
+            return (long) availableMembers.indexOf(memberId);
+        }
+        return (long) unavailableMembers.indexOf(memberId);
+    }
+
+    private static String determineAvailability(boolean isAvailable) {
+        if (isAvailable) {
+            return AppointmentAvailability.AVAILABLE.getMessage();
+        }
+        return AppointmentAvailability.UNAVAILABLE.getMessage();
+    }
+
+    private static String findMemberName(Long memberId, Map<Long, String> memberNames) {
+        if (!memberNames.containsKey(memberId)) {
+            throw new AppointmentException(AppointmentErrorCode.MEMBER_NOT_FOUND);
+        }
+        return memberNames.get(memberId);
+    }
+
+    private static Long countLikes(AppointmentOption option, LikeRepository likeRepository) {
+        return likeRepository.countByAppointmentOptionId(option.getId());
+    }
+
+    private static boolean checkIfLiked(AppointmentOption option, Long memberId, LikeRepository likeRepository) {
+        return likeRepository.existsByAppointmentOptionIdAndAppointmentMemberId(option.getId(), memberId);
+    }
+
+    private static Long findGroupMemberCount(AppointmentOption option, GroupRepository groupRepository) {
+        return groupRepository.findById(option.getAppointment().getGroup().getId())
+                .map(group -> group.getCount().value())
+                .orElse(0L);
+    }
+
+    private static AppointmentOptionResponse createAppointmentOptionResponse(
+            AppointmentOption option,
+            Long memberId,
+            List<Long> availableMembers,
+            List<Long> unavailableMembers,
+            String availability,
+            Long position,
+            String myName,
+            LikeRepository likeRepository,
+            GroupRepository groupRepository,
+            Map<Long, String> memberNames
+    ) {
+        Long likeCount = countLikes(option, likeRepository);
+        boolean liked = checkIfLiked(option, memberId, likeRepository);
+        Long groupMemberCount = findGroupMemberCount(option, groupRepository);
+
+        List<String> availableNames = mapMemberIdsToNames(availableMembers, memberNames);
+        List<String> unavailableNames = mapMemberIdsToNames(unavailableMembers, memberNames);
+
+        return AppointmentOptionResponse.of(
+                option.getId(), likeCount, liked, groupMemberCount,
+                (long) availableMembers.size(),
+                AppointmentOptionTimeResponse.of(option.getStartTime(), option.getStartTime(), option.getEndTime()),
+                AppointmentMyInfoResponse.of(availability, position, myName),
+                AvailableFriendsResponse.of((long) availableNames.size(), availableNames),
+                UnavailableFriendsResponse.of((long) unavailableNames.size(), unavailableNames)
+        );
+    }
+
+
+    private static List<String> mapMemberIdsToNames(List<Long> memberIds, Map<Long, String> memberNames) {
+        return memberIds.stream().map(memberNames::get).toList();
+    }
+}

--- a/src/main/java/org/noostak/appointment/util/AppointmentOptionSorter.java
+++ b/src/main/java/org/noostak/appointment/util/AppointmentOptionSorter.java
@@ -1,0 +1,58 @@
+package org.noostak.appointment.util;
+
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class AppointmentOptionSorter {
+
+    private static final int MAX_RESULTS = 5;
+
+    public static List<AppointmentOption> sortAndFilterOptions(
+            List<AppointmentOption> options,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        Map<AppointmentOption, Integer> optionAvailabilityCounts = calculateOptionAvailability(options, memberAvailability);
+
+        return groupByAvailability(optionAvailabilityCounts);
+    }
+
+    private static Map<AppointmentOption, Integer> calculateOptionAvailability(
+            List<AppointmentOption> options,
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability
+    ) {
+        return options.stream()
+                .collect(Collectors.toMap(
+                        option -> option,
+                        option -> calculateAvailableMembers(option, memberAvailability)
+                ));
+    }
+
+    private static List<AppointmentOption> groupByAvailability(Map<AppointmentOption, Integer> availabilityCounts) {
+        return availabilityCounts.entrySet().stream()
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getValue,
+                        TreeMap::new,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toList())
+                ))
+                .descendingMap()
+                .values().stream()
+                .flatMap(List::stream)
+                .limit(MAX_RESULTS)
+                .toList();
+    }
+
+    private static int calculateAvailableMembers(AppointmentOption option,
+                                                 Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability) {
+        TimeSlot timeSlot = getTimeSlot(option);
+        return (int) memberAvailability.values().stream()
+                .filter(times -> AppointmentAvailabilityMatcher.satisfiesDuration(times, timeSlot))
+                .count();
+    }
+
+    private static TimeSlot getTimeSlot(AppointmentOption option) {
+        return TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime());
+    }
+}

--- a/src/main/java/org/noostak/appointment/util/AppointmentTimeSplitter.java
+++ b/src/main/java/org/noostak/appointment/util/AppointmentTimeSplitter.java
@@ -1,0 +1,32 @@
+package org.noostak.appointment.util;
+
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AppointmentTimeSplitter {
+
+    public static List<TimeSlot> splitTimeSlots(LocalDateTime date, LocalDateTime startTime, LocalDateTime endTime, int durationMinutes) {
+        if (durationMinutes <= 0) {
+            throw new AppointmentException(AppointmentErrorCode.INVALID_DURATION);
+        }
+
+        List<TimeSlot> timeSlots = new ArrayList<>();
+        LocalDateTime slotStart = startTime;
+
+        while (slotStart.isBefore(endTime)) {
+            LocalDateTime slotEnd = slotStart.plusMinutes(durationMinutes);
+            if (slotEnd.isAfter(endTime)) {
+                slotEnd = endTime;
+            }
+
+            timeSlots.add(TimeSlot.of(date, slotStart, slotEnd));
+            slotStart = slotEnd;
+        }
+
+        return timeSlots;
+    }
+}

--- a/src/main/java/org/noostak/appointment/util/TimeSlot.java
+++ b/src/main/java/org/noostak/appointment/util/TimeSlot.java
@@ -1,0 +1,10 @@
+package org.noostak.appointment.util;
+
+import java.time.LocalDateTime;
+
+public record TimeSlot(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
+
+    public static TimeSlot of(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
+        return new TimeSlot(date, start, end);
+    }
+}

--- a/src/main/java/org/noostak/appointmentmember/domain/AppointmentMemberAvailableTimesRepository.java
+++ b/src/main/java/org/noostak/appointmentmember/domain/AppointmentMemberAvailableTimesRepository.java
@@ -1,12 +1,13 @@
 package org.noostak.appointmentmember.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
-public interface AppointmentMemberAvailableTimesRepository extends JpaRepository<AppointmentMemberAvailableTime, Long>{
+public interface AppointmentMemberAvailableTimesRepository extends JpaRepository<AppointmentMemberAvailableTime, Long> {
 
     List<AppointmentMemberAvailableTime> findByAppointmentMember(AppointmentMember appointmentMember);
+
+    List<AppointmentMemberAvailableTime> findByAppointmentMember_AppointmentId(Long appointmentId);
 
     void deleteByAppointmentMember(AppointmentMember appointmentMember);
 }

--- a/src/main/java/org/noostak/appointmentmember/domain/AppointmentMemberRepository.java
+++ b/src/main/java/org/noostak/appointmentmember/domain/AppointmentMemberRepository.java
@@ -2,5 +2,7 @@ package org.noostak.appointmentmember.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AppointmentMemberRepository extends JpaRepository<AppointmentMember, Long>, AppointmentMemberRepositoryCustom {
 }

--- a/src/main/java/org/noostak/group/api/GroupController.java
+++ b/src/main/java/org/noostak/group/api/GroupController.java
@@ -6,6 +6,7 @@ import org.noostak.group.application.GroupService;
 import org.noostak.group.dto.request.GroupCreateRequest;
 import org.noostak.group.dto.response.create.GroupCreateResponse;
 import org.noostak.group.dto.response.info.GroupInfoResponse;
+import org.noostak.group.dto.response.ongoing.GroupOngoingAppointmentsResponse;
 import org.noostak.group.dto.response.retrieve.GroupsRetrieveResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -50,5 +51,15 @@ public class GroupController {
         Long memberId = 1L;
         GroupInfoResponse groupInfo = groupService.getGroupInfo(memberId, groupId);
         return ResponseEntity.ok(SuccessResponse.of(GROUP_INFO, groupInfo));
+    }
+
+    @GetMapping("/{groupId}/appointments/ongoing")
+    public ResponseEntity<SuccessResponse<GroupOngoingAppointmentsResponse>> getGroupOngoingAppointments(
+            // @AuthenticationPrincipal Long memberId,
+            @PathVariable Long groupId
+    ) {
+        Long memberId = 1L;
+        GroupOngoingAppointmentsResponse groupOngoingAppointments = groupService.getGroupOngoingAppointments(memberId, groupId);
+        return ResponseEntity.ok(SuccessResponse.of(GROUP_ONGOING_APPOINTMENTS_LOADED, groupOngoingAppointments));
     }
 }

--- a/src/main/java/org/noostak/group/application/GroupService.java
+++ b/src/main/java/org/noostak/group/application/GroupService.java
@@ -1,10 +1,12 @@
 package org.noostak.group.application;
 
 import lombok.RequiredArgsConstructor;
+import org.noostak.group.application.ongoing.GroupOngoingAppointmentService;
 import org.noostak.group.dto.request.GroupCreateRequest;
 import org.noostak.group.dto.response.create.GroupCreateInternalResponse;
 import org.noostak.group.dto.response.create.GroupCreateResponse;
 import org.noostak.group.dto.response.info.GroupInfoResponse;
+import org.noostak.group.dto.response.ongoing.GroupOngoingAppointmentsResponse;
 import org.noostak.group.dto.response.retrieve.GroupsRetrieveResponse;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +19,7 @@ public class GroupService {
     private final GroupCreateService groupCreateService;
     private final GroupRetrieveService groupRetrieveService;
     private final GroupInfoService groupInfoService;
+    private final GroupOngoingAppointmentService groupOngoingAppointmentsService;
 
     public GroupCreateResponse createGroup(Long memberId, GroupCreateRequest request) throws IOException {
         GroupCreateInternalResponse response = groupCreateService.createGroup(memberId, request);
@@ -29,5 +32,9 @@ public class GroupService {
 
     public GroupInfoResponse getGroupInfo(Long memberId, Long groupId) {
         return groupInfoService.getGroupInfo(memberId, groupId);
+    }
+
+    public GroupOngoingAppointmentsResponse getGroupOngoingAppointments(Long memberId, Long groupId) {
+        return groupOngoingAppointmentsService.getGroupOngoingAppointments(memberId, groupId);
     }
 }

--- a/src/main/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentService.java
+++ b/src/main/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentService.java
@@ -1,0 +1,7 @@
+package org.noostak.group.application.ongoing;
+
+import org.noostak.group.dto.response.ongoing.GroupOngoingAppointmentsResponse;
+
+public interface GroupOngoingAppointmentService {
+    GroupOngoingAppointmentsResponse getGroupOngoingAppointments(Long memberId, Long groupId);
+}

--- a/src/main/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentServiceImpl.java
+++ b/src/main/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentServiceImpl.java
@@ -1,0 +1,88 @@
+package org.noostak.group.application.ongoing;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.application.recommendation.AppointmentRecommendationFacade;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.domain.AppointmentRepository;
+import org.noostak.appointment.dto.response.AppointmentOptionResponse;
+import org.noostak.appointment.dto.response.AppointmentOptionTimeResponse;
+import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepository;
+import org.noostak.group.dto.response.ongoing.*;
+import org.noostak.infra.S3Service;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupOngoingAppointmentServiceImpl implements GroupOngoingAppointmentService {
+
+    private final AppointmentRecommendationFacade recommendationFacade;
+    private final GroupRepository groupRepository;
+    private final AppointmentRepository appointmentRepository;
+    private final S3Service s3Service;
+
+    @Override
+    public GroupOngoingAppointmentsResponse getGroupOngoingAppointments(Long memberId, Long groupId) {
+        Group group = findGroupById(groupId);
+        List<Appointment> appointments = findAllAppointmentsByGroupId(groupId);
+
+        List<OngoingAppointmentResponse> ongoingAppointments = appointments.stream()
+                .map(appointment -> findBestOptionForAppointment(memberId, appointment))
+                .flatMap(Optional::stream)
+                .collect(Collectors.toList());
+
+        return buildGroupOngoingAppointmentsResponse(group, ongoingAppointments);
+    }
+
+    private List<Appointment> findAllAppointmentsByGroupId(Long groupId) {
+        return appointmentRepository.findAllByGroupId(groupId);
+    }
+
+    private Optional<OngoingAppointmentResponse> findBestOptionForAppointment(Long memberId, Appointment appointment) {
+        return recommendationFacade.getRecommendedOptions(memberId, appointment.getId(), appointment).stream()
+                .flatMap(priorityGroup -> priorityGroup.options().stream())
+                .sorted((o1, o2) -> Long.compare(o2.availableMemberCount(), o1.availableMemberCount()))
+                .findFirst()
+                .map(option -> buildOngoingAppointmentResponse(appointment, option));
+    }
+
+    private GroupOngoingAppointmentsResponse buildGroupOngoingAppointmentsResponse(Group group, List<OngoingAppointmentResponse> ongoingAppointments) {
+        return GroupOngoingAppointmentsResponse.of(
+                GroupOngoingInfoResponse.of(
+                        group.getName().value(),
+                        s3Service.getImageUrl(group.getKey().value()),
+                        group.getCount().value(),
+                        group.getCode().value()
+                ),
+                ongoingAppointments
+        );
+    }
+
+    private Group findGroupById(Long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private OngoingAppointmentResponse buildOngoingAppointmentResponse(Appointment appointment, AppointmentOptionResponse recommendedOption) {
+        AppointmentOptionTimeResponse optionTime = recommendedOption.appointmentOptionTime();
+
+        return OngoingAppointmentResponse.of(
+                appointment.getId(),
+                appointment.getName().value(),
+                recommendedOption.availableMemberCount(),
+                List.of(AppointmentOngoingHostSelectionTimeResponse.of(
+                        optionTime.date(),
+                        optionTime.startTime(),
+                        optionTime.endTime()
+                ))
+        );
+    }
+}

--- a/src/main/java/org/noostak/group/common/success/GroupSuccessCode.java
+++ b/src/main/java/org/noostak/group/common/success/GroupSuccessCode.java
@@ -12,7 +12,9 @@ public enum GroupSuccessCode implements SuccessCode {
 
     GROUP_RETRIEVED(HttpStatus.OK, "그룹이 성공적으로 조회되었습니다."),
 
-    GROUP_INFO(HttpStatus.OK, "그룹 정보가 성공적으로 조회되었습니다.")
+    GROUP_INFO(HttpStatus.OK, "그룹 정보가 성공적으로 조회되었습니다."),
+
+    GROUP_ONGOING_APPOINTMENTS_LOADED(HttpStatus.OK, "그룹의 진행중인 약속이 성공적으로 조회되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/noostak/group/dto/response/ongoing/AppointmentOngoingHostSelectionTimeResponse.java
+++ b/src/main/java/org/noostak/group/dto/response/ongoing/AppointmentOngoingHostSelectionTimeResponse.java
@@ -1,0 +1,17 @@
+package org.noostak.group.dto.response.ongoing;
+
+import java.time.LocalDateTime;
+
+public record AppointmentOngoingHostSelectionTimeResponse(
+        LocalDateTime date,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+    public static AppointmentOngoingHostSelectionTimeResponse of(
+            LocalDateTime date,
+            LocalDateTime startTime,
+            LocalDateTime endTime
+    ) {
+        return new AppointmentOngoingHostSelectionTimeResponse(date, startTime, endTime);
+    }
+}

--- a/src/main/java/org/noostak/group/dto/response/ongoing/GroupOngoingAppointmentsResponse.java
+++ b/src/main/java/org/noostak/group/dto/response/ongoing/GroupOngoingAppointmentsResponse.java
@@ -1,0 +1,15 @@
+package org.noostak.group.dto.response.ongoing;
+
+import java.util.List;
+
+public record GroupOngoingAppointmentsResponse(
+        GroupOngoingInfoResponse groupOngoingInfo,
+        List<OngoingAppointmentResponse> ongoingAppointments
+) {
+    public static GroupOngoingAppointmentsResponse of(
+            GroupOngoingInfoResponse groupOngoingInfo,
+            List<OngoingAppointmentResponse> ongoingAppointments
+    ) {
+        return new GroupOngoingAppointmentsResponse(groupOngoingInfo, ongoingAppointments);
+    }
+}

--- a/src/main/java/org/noostak/group/dto/response/ongoing/GroupOngoingInfoResponse.java
+++ b/src/main/java/org/noostak/group/dto/response/ongoing/GroupOngoingInfoResponse.java
@@ -1,0 +1,17 @@
+package org.noostak.group.dto.response.ongoing;
+
+public record GroupOngoingInfoResponse(
+        String groupName,
+        String groupProfileImageUrl,
+        Long groupMemberCount,
+        String groupInviteCode
+) {
+    public static GroupOngoingInfoResponse of(
+            String groupName,
+            String groupProfileImageUrl,
+            Long groupMemberCount,
+            String groupInviteCode
+    ) {
+        return new GroupOngoingInfoResponse(groupName, groupProfileImageUrl, groupMemberCount, groupInviteCode);
+    }
+}

--- a/src/main/java/org/noostak/group/dto/response/ongoing/OngoingAppointmentResponse.java
+++ b/src/main/java/org/noostak/group/dto/response/ongoing/OngoingAppointmentResponse.java
@@ -1,0 +1,19 @@
+package org.noostak.group.dto.response.ongoing;
+
+import java.util.List;
+
+public record OngoingAppointmentResponse(
+        Long appointmentId,
+        String appointmentName,
+        Long availableGroupMemberCount,
+        List<AppointmentOngoingHostSelectionTimeResponse> hostSelectionTimes
+) {
+    public static OngoingAppointmentResponse of(
+            Long appointmentId,
+            String appointmentName,
+            Long availableGroupMemberCount,
+            List<AppointmentOngoingHostSelectionTimeResponse> hostSelectionTimes
+    ) {
+        return new OngoingAppointmentResponse(appointmentId, appointmentName, availableGroupMemberCount, hostSelectionTimes);
+    }
+}

--- a/src/main/java/org/noostak/likes/domain/Like.java
+++ b/src/main/java/org/noostak/likes/domain/Like.java
@@ -11,11 +11,12 @@ import org.noostak.likes.domain.vo.LikesCount;
 @Entity
 @Getter
 @RequiredArgsConstructor
-public class Likes extends BaseTimeEntity {
+@Table(name = "likes")
+public class Like extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "likes_id")
+    @Column(name = "like_id")
     private Long id;
 
     @Embedded
@@ -29,4 +30,14 @@ public class Likes extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "appointment_option_id")
     private AppointmentOption appointmentOption;
+
+    private Like(LikesCount likesCount, AppointmentMember appointmentMember, AppointmentOption appointmentOption) {
+        this.likesCount = likesCount;
+        this.appointmentMember = appointmentMember;
+        this.appointmentOption = appointmentOption;
+    }
+
+    public static Like of(LikesCount likesCount, AppointmentMember appointmentMember, AppointmentOption appointmentOption) {
+        return new Like(likesCount, appointmentMember, appointmentOption);
+    }
 }

--- a/src/main/java/org/noostak/likes/domain/LikeRepository.java
+++ b/src/main/java/org/noostak/likes/domain/LikeRepository.java
@@ -1,0 +1,10 @@
+package org.noostak.likes.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Long countByAppointmentOptionId(Long appointmentOptionId);
+
+    boolean existsByAppointmentOptionIdAndAppointmentMemberId(Long appointmentOptionId, Long appointmentMemberId);
+}

--- a/src/test/java/org/noostak/appointment/application/AppointmentCreateServiceImplTest.java
+++ b/src/test/java/org/noostak/appointment/application/AppointmentCreateServiceImplTest.java
@@ -1,6 +1,7 @@
 package org.noostak.appointment.application;
 
 import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.create.AppointmentCreateServiceImpl;
 import org.noostak.appointment.common.exception.AppointmentErrorCode;
 import org.noostak.appointment.common.exception.AppointmentException;
 import org.noostak.appointment.domain.*;

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryServiceImplTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryServiceImplTest.java
@@ -6,29 +6,32 @@ import org.noostak.appointment.common.exception.AppointmentException;
 import org.noostak.appointment.domain.*;
 import org.noostak.appointment.util.TimeSlot;
 import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepository;
 import org.noostak.group.domain.GroupRepositoryTest;
 import org.noostak.member.MemberRepositoryTest;
 import org.noostak.member.domain.Member;
+import org.noostak.member.domain.MemberRepository;
 import org.noostak.member.domain.vo.AuthId;
 import org.noostak.member.domain.vo.AuthType;
 import org.noostak.member.domain.vo.MemberName;
 import org.noostak.member.domain.vo.MemberProfileImageKey;
 import org.noostak.membergroup.MemberGroupRepositoryTest;
 import org.noostak.membergroup.domain.MemberGroup;
+import org.noostak.membergroup.domain.MemberGroupRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
-class AppointmentHostSelectedTimeQueryServiceTest {
+class AppointmentHostSelectedTimeQueryServiceImplTest {
 
     private AppointmentHostSelectedTimeQueryService queryService;
-    private AppointmentHostSelectionTimeRepositoryTest repository;
-    private AppointmentRepositoryTest appointmentRepository;
-    private MemberRepositoryTest memberRepository;
-    private GroupRepositoryTest groupRepository;
-    private MemberGroupRepositoryTest memberGroupRepository;
+    private AppointmentHostSelectionTimeRepositoryTest appointmentHostSelectionTimeRepository;
+    private AppointmentRepository appointmentRepository;
+    private MemberRepository memberRepository;
+    private GroupRepository groupRepository;
+    private MemberGroupRepository memberGroupRepository;
 
     private Long savedMemberId;
     private Long savedGroupId;
@@ -42,7 +45,7 @@ class AppointmentHostSelectedTimeQueryServiceTest {
 
     @AfterEach
     void tearDown() {
-        repository.deleteAll();
+        appointmentHostSelectionTimeRepository.deleteAll();
         appointmentRepository.deleteAll();
         memberRepository.deleteAll();
         groupRepository.deleteAll();
@@ -79,7 +82,7 @@ class AppointmentHostSelectedTimeQueryServiceTest {
         @DisplayName("저장된 호스트 선택 시간이 없을 경우 예외 발생")
         void shouldFailWhenHostSelectionTimeNotFound() {
             // Given
-            repository.deleteByAppointmentId(savedAppointmentId);
+            appointmentHostSelectionTimeRepository.deleteByAppointmentId(savedAppointmentId);
 
             // When & Then
             assertThatThrownBy(() -> queryService.splitHostSelectedTimeSlots(savedAppointmentId, 60L))
@@ -101,17 +104,18 @@ class AppointmentHostSelectedTimeQueryServiceTest {
                 startTime,
                 endTime
         );
-        repository.save(selectionTime);
+        appointmentHostSelectionTimeRepository.save(selectionTime);
     }
 
     private void initializeRepositories() {
-        repository = new AppointmentHostSelectionTimeRepositoryTest();
+        appointmentHostSelectionTimeRepository = new AppointmentHostSelectionTimeRepositoryTest();
         appointmentRepository = new AppointmentRepositoryTest();
         memberRepository = new MemberRepositoryTest();
         groupRepository = new GroupRepositoryTest();
         memberGroupRepository = new MemberGroupRepositoryTest();
-        queryService = new AppointmentHostSelectedTimeQueryService(repository);
+        queryService = new org.noostak.appointment.application.recommendation.impl.AppointmentHostSelectedTimeQueryServiceImpl(appointmentHostSelectionTimeRepository);
     }
+
 
     private void initializeTestData() {
         savedMemberId = createAndSaveMember("사용자One");

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentHostSelectedTimeQueryServiceTest.java
@@ -1,0 +1,164 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.*;
+import org.noostak.appointment.util.TimeSlot;
+import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepositoryTest;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.Member;
+import org.noostak.member.domain.vo.AuthId;
+import org.noostak.member.domain.vo.AuthType;
+import org.noostak.member.domain.vo.MemberName;
+import org.noostak.member.domain.vo.MemberProfileImageKey;
+import org.noostak.membergroup.MemberGroupRepositoryTest;
+import org.noostak.membergroup.domain.MemberGroup;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AppointmentHostSelectedTimeQueryServiceTest {
+
+    private AppointmentHostSelectedTimeQueryService queryService;
+    private AppointmentHostSelectionTimeRepositoryTest repository;
+    private AppointmentRepositoryTest appointmentRepository;
+    private MemberRepositoryTest memberRepository;
+    private GroupRepositoryTest groupRepository;
+    private MemberGroupRepositoryTest memberGroupRepository;
+
+    private Long savedMemberId;
+    private Long savedGroupId;
+    private Long savedAppointmentId;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        repository.deleteAll();
+        appointmentRepository.deleteAll();
+        memberRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("1️⃣ 호스트 선택 시간이 정상적으로 분할된다.")
+        void shouldSplitHostSelectedTimeSlotsSuccessfully() {
+            // Given
+            Long duration = 30L;
+
+            // When
+            List<TimeSlot> timeSlots = queryService.splitHostSelectedTimeSlots(savedAppointmentId, duration);
+
+            // Then
+            assertThat(timeSlots)
+                    .withFailMessage("분할된 TimeSlot 리스트가 비어 있음! appointmentId: " + savedAppointmentId)
+                    .isNotEmpty();
+            assertThat(timeSlots.get(0).start()).isEqualTo(LocalDateTime.of(2024, 3, 15, 10, 0));
+            assertThat(timeSlots.get(timeSlots.size() - 1).end()).isEqualTo(LocalDateTime.of(2024, 3, 15, 11, 0));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("저장된 호스트 선택 시간이 없을 경우 예외 발생")
+        void shouldFailWhenHostSelectionTimeNotFound() {
+            // Given
+            repository.deleteByAppointmentId(savedAppointmentId);
+
+            // When & Then
+            assertThatThrownBy(() -> queryService.splitHostSelectedTimeSlots(savedAppointmentId, 60L))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessage(AppointmentErrorCode.HOST_SELECTION_TIME_NOT_FOUND.getMessage());
+        }
+    }
+
+    private void saveHostSelectionTime(Long appointmentId) {
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_NOT_FOUND));
+
+        LocalDateTime startTime = LocalDateTime.of(2024, 3, 15, 10, 0);
+        LocalDateTime endTime = LocalDateTime.of(2024, 3, 15, 11, 0);
+
+        AppointmentHostSelectionTime selectionTime = AppointmentHostSelectionTime.of(
+                appointment,
+                startTime.toLocalDate().atStartOfDay(),
+                startTime,
+                endTime
+        );
+        repository.save(selectionTime);
+    }
+
+    private void initializeRepositories() {
+        repository = new AppointmentHostSelectionTimeRepositoryTest();
+        appointmentRepository = new AppointmentRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        queryService = new AppointmentHostSelectedTimeQueryService(repository);
+    }
+
+    private void initializeTestData() {
+        savedMemberId = createAndSaveMember("사용자One");
+        savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+        saveMemberGroup(savedMemberId, savedGroupId);
+        savedAppointmentId = createAndSaveAppointment(savedMemberId, "팀미팅");
+        saveHostSelectionTime(savedAppointmentId);
+    }
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                org.noostak.group.domain.vo.GroupName.from(groupName),
+                org.noostak.group.domain.vo.GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private void saveMemberGroup(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        memberGroupRepository.save(MemberGroup.of(member, group));
+    }
+
+    private Long createAndSaveAppointment(Long memberId, String appointmentName) {
+        Appointment appointment = appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(savedGroupId).orElseThrow(),
+                        memberId,
+                        appointmentName,
+                        60L,
+                        "중요",
+                        org.noostak.appointment.domain.vo.AppointmentStatus.PROGRESS
+                )
+        );
+        return appointment.getId();
+    }
+}

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryServiceTest.java
@@ -1,0 +1,175 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.*;
+import org.noostak.appointmentmember.domain.*;
+import org.noostak.appointmentmember.domain.repository.AppointmentMemberAvailableTimesRepositoryTest;
+import org.noostak.appointmentmember.domain.repository.AppointmentMemberRepositoryTest;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepositoryTest;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.*;
+import org.noostak.member.domain.vo.*;
+import org.noostak.membergroup.domain.MemberGroup;
+import org.noostak.membergroup.MemberGroupRepositoryTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AppointmentMemberAvailabilityQueryServiceTest {
+
+    private AppointmentMemberAvailabilityQueryService queryService;
+    private AppointmentMemberAvailableTimesRepositoryTest availableTimesRepository;
+    private AppointmentMemberRepositoryTest appointmentMemberRepository;
+    private AppointmentRepositoryTest appointmentRepository;
+    private GroupRepositoryTest groupRepository;
+    private MemberRepositoryTest memberRepository;
+    private MemberGroupRepositoryTest memberGroupRepository;
+
+    private Long savedMemberId;
+    private Long savedGroupId;
+    private Long savedAppointmentId;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        availableTimesRepository.deleteAll();
+        appointmentMemberRepository.deleteAll();
+        appointmentRepository.deleteAll();
+        memberRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("1️⃣ 멤버의 가용 시간을 정상적으로 조회한다.")
+        void shouldFindAvailableTimeSlotsSuccessfully() {
+            // When
+            Map<Long, List<AppointmentMemberAvailableTime>> availableTimeSlots =
+                    queryService.findAvailableTimeSlotsByAppointmentId(savedAppointmentId);
+
+            // Then
+            assertThat(availableTimeSlots)
+                    .withFailMessage("멤버 가용 시간이 비어 있음!")
+                    .isNotEmpty();
+            assertThat(availableTimeSlots).containsKey(savedMemberId);
+            assertThat(availableTimeSlots.get(savedMemberId)).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("저장된 멤버 가용 시간이 없을 경우 예외 발생")
+        void shouldFailWhenNoMemberAvailabilityFound() {
+            // Given
+            availableTimesRepository.deleteAll();
+
+            // When & Then
+            assertThatThrownBy(() -> queryService.findAvailableTimeSlotsByAppointmentId(savedAppointmentId))
+                    .isInstanceOf(AppointmentException.class)
+                    .hasMessage(AppointmentErrorCode.MEMBER_AVAILABILITY_NOT_FOUND.getMessage());
+        }
+    }
+
+    private void initializeRepositories() {
+        availableTimesRepository = new AppointmentMemberAvailableTimesRepositoryTest();
+        appointmentMemberRepository = new AppointmentMemberRepositoryTest();
+        appointmentRepository = new AppointmentRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        queryService = new AppointmentMemberAvailabilityQueryService(availableTimesRepository);
+    }
+
+    private void initializeTestData() {
+        savedMemberId = createAndSaveMember("사용자One");
+        savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+        saveMemberGroup(savedMemberId, savedGroupId);
+        savedAppointmentId = createAndSaveAppointment(savedMemberId, "팀미팅");
+        saveMemberAvailability(savedMemberId, savedAppointmentId);
+    }
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                org.noostak.group.domain.vo.GroupName.from(groupName),
+                org.noostak.group.domain.vo.GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private void saveMemberGroup(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        memberGroupRepository.save(MemberGroup.of(member, group));
+    }
+
+    private Long createAndSaveAppointment(Long memberId, String appointmentName) {
+        Appointment appointment = appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(savedGroupId).orElseThrow(),
+                        memberId,
+                        appointmentName,
+                        60L,
+                        "중요",
+                        org.noostak.appointment.domain.vo.AppointmentStatus.PROGRESS
+                )
+        );
+        return appointment.getId();
+    }
+
+    private void saveMemberAvailability(Long memberId, Long appointmentId) {
+        Appointment appointment = appointmentRepository.findById(appointmentId).orElseThrow();
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        AppointmentMember appointmentMember = createAppointmentMember(AppointmentAvailability.AVAILABLE, memberId, appointmentId);
+
+        LocalDateTime date = LocalDateTime.of(2024, 3, 15, 0, 0);
+
+        List<AppointmentMemberAvailableTime> availableTimes = List.of(
+                AppointmentMemberAvailableTime.of(appointmentMember, date, LocalDateTime.of(2024, 3, 15, 10, 0), LocalDateTime.of(2024, 3, 15, 10, 30)),
+                AppointmentMemberAvailableTime.of(appointmentMember, date, LocalDateTime.of(2024, 3, 15, 10, 30), LocalDateTime.of(2024, 3, 15, 11, 0))
+        );
+
+        availableTimesRepository.saveAll(availableTimes);
+        appointmentMember.updateAvailableTimes(availableTimes);
+    }
+
+    private AppointmentMember createAppointmentMember(AppointmentAvailability availability, Long memberId, Long appointmentId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.MEMBER_NOT_FOUND));
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_NOT_FOUND));
+
+        return appointmentMemberRepository.save(AppointmentMember.of(availability, appointment, member));
+    }
+}

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentMemberAvailabilityQueryServiceTest.java
@@ -1,6 +1,7 @@
 package org.noostak.appointment.application.recommendation;
 
 import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.recommendation.impl.AppointmentMemberAvailabilityQueryServiceImpl;
 import org.noostak.appointment.common.exception.AppointmentErrorCode;
 import org.noostak.appointment.common.exception.AppointmentException;
 import org.noostak.appointment.domain.*;
@@ -96,7 +97,7 @@ class AppointmentMemberAvailabilityQueryServiceTest {
         groupRepository = new GroupRepositoryTest();
         memberRepository = new MemberRepositoryTest();
         memberGroupRepository = new MemberGroupRepositoryTest();
-        queryService = new AppointmentMemberAvailabilityQueryService(availableTimesRepository);
+        queryService = new AppointmentMemberAvailabilityQueryServiceImpl(availableTimesRepository);
     }
 
     private void initializeTestData() {

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandServiceTest.java
@@ -1,0 +1,157 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.domain.*;
+import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
+import org.noostak.appointmentoption.domain.*;
+import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepositoryTest;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.*;
+import org.noostak.member.domain.vo.*;
+import org.noostak.membergroup.MemberGroupRepositoryTest;
+import org.noostak.membergroup.domain.MemberGroup;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AppointmentOptionCommandServiceTest {
+
+    private AppointmentOptionCommandService commandService;
+    private AppointmentOptionRepositoryTest appointmentOptionRepository;
+    private AppointmentRepositoryTest appointmentRepository;
+    private GroupRepositoryTest groupRepository;
+    private MemberRepositoryTest memberRepository;
+    private MemberGroupRepositoryTest memberGroupRepository;
+
+    private Long savedAppointmentId;
+    private Appointment savedAppointment;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        appointmentOptionRepository.deleteAll();
+        appointmentRepository.deleteAll();
+        memberRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("약속 옵션이 정상적으로 저장된다.")
+        void shouldSaveAppointmentOptionsSuccessfully() {
+            List<AppointmentOptionAvailabilityResponse> optionDTOs = createOptionDTOs();
+
+            List<AppointmentOption> savedOptions = commandService.saveOptions(savedAppointment, optionDTOs);
+
+            assertThat(savedOptions).isNotEmpty();
+            assertThat(savedOptions).hasSize(2);
+            assertThat(savedOptions.get(0).getDate()).isEqualTo(getTestDateTime());
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("빈 옵션 리스트가 주어질 경우 빈 리스트 반환")
+        void shouldReturnEmptyListWhenOptionsAreEmpty() {
+            List<AppointmentOptionAvailabilityResponse> emptyOptions = List.of();
+
+            List<AppointmentOption> savedOptions = commandService.saveOptions(savedAppointment, emptyOptions);
+
+            assertThat(savedOptions).isEmpty();
+        }
+    }
+
+    private void initializeRepositories() {
+        appointmentOptionRepository = new AppointmentOptionRepositoryTest();
+        appointmentRepository = new AppointmentRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        commandService = new AppointmentOptionCommandService(appointmentOptionRepository);
+    }
+
+    private void initializeTestData() {
+        Long savedMemberId = createAndSaveMember("사용자One");
+        Long savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+        saveMemberGroup(savedMemberId, savedGroupId);
+        savedAppointmentId = createAndSaveAppointment(savedMemberId, "팀미팅");
+        savedAppointment = appointmentRepository.findById(savedAppointmentId).orElseThrow();
+    }
+
+    private List<AppointmentOptionAvailabilityResponse> createOptionDTOs() {
+        return List.of(
+                new AppointmentOptionAvailabilityResponse(
+                        getTestDateTime(),
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 30),
+                        List.of(1L, 2L)
+                ),
+                new AppointmentOptionAvailabilityResponse(
+                        getTestDateTime(),
+                        LocalDateTime.of(2024, 3, 15, 10, 30),
+                        LocalDateTime.of(2024, 3, 15, 11, 0),
+                        List.of(2L, 3L)
+                )
+        );
+    }
+
+    private LocalDateTime getTestDateTime() {
+        return LocalDateTime.of(2024, 3, 15, 0, 0);
+    }
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                org.noostak.group.domain.vo.GroupName.from(groupName),
+                org.noostak.group.domain.vo.GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private void saveMemberGroup(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        memberGroupRepository.save(MemberGroup.of(member, group));
+    }
+
+    private Long createAndSaveAppointment(Long memberId, String appointmentName) {
+        Appointment appointment = appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(memberId).orElseThrow(),
+                        memberId,
+                        appointmentName,
+                        60L,
+                        "중요",
+                        org.noostak.appointment.domain.vo.AppointmentStatus.PROGRESS
+                )
+        );
+        return appointment.getId();
+    }
+}

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionCommandServiceTest.java
@@ -1,6 +1,7 @@
 package org.noostak.appointment.application.recommendation;
 
 import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.recommendation.impl.AppointmentOptionCommandServiceImpl;
 import org.noostak.appointment.domain.*;
 import org.noostak.appointment.dto.response.AppointmentOptionAvailabilityResponse;
 import org.noostak.appointmentoption.domain.*;
@@ -82,7 +83,7 @@ class AppointmentOptionCommandServiceTest {
         groupRepository = new GroupRepositoryTest();
         memberRepository = new MemberRepositoryTest();
         memberGroupRepository = new MemberGroupRepositoryTest();
-        commandService = new AppointmentOptionCommandService(appointmentOptionRepository);
+        commandService = new AppointmentOptionCommandServiceImpl(appointmentOptionRepository);
     }
 
     private void initializeTestData() {

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityServiceTest.java
@@ -1,0 +1,203 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.common.exception.AppointmentErrorCode;
+import org.noostak.appointment.common.exception.AppointmentException;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.domain.AppointmentRepository;
+import org.noostak.appointment.domain.AppointmentRepositoryTest;
+import org.noostak.appointment.dto.response.AppointmentPriorityGroupResponse;
+import org.noostak.appointmentmember.domain.AppointmentMember;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentmember.domain.AppointmentMemberRepository;
+import org.noostak.appointmentmember.domain.repository.AppointmentMemberRepositoryTest;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.group.domain.Group;
+import org.noostak.group.domain.GroupRepository;
+import org.noostak.group.domain.GroupRepositoryTest;
+import org.noostak.likes.domain.LikeRepository;
+import org.noostak.likes.domain.LikeRepositoryTest;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.*;
+import org.noostak.member.domain.vo.*;
+import org.noostak.membergroup.MemberGroupRepositoryTest;
+import org.noostak.membergroup.domain.MemberGroup;
+import org.noostak.membergroup.domain.MemberGroupRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AppointmentOptionPriorityServiceTest {
+
+    private AppointmentOptionPriorityService priorityService;
+    private LikeRepository likeRepository;
+    private GroupRepository groupRepository;
+    private MemberRepository memberRepository;
+    private MemberGroupRepository memberGroupRepository;
+    private AppointmentRepository appointmentRepository;
+    private AppointmentMemberRepository appointmentMemberRepository;
+
+    private Long savedMemberId;
+    private Long savedGroupId;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        likeRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("우선순위 그룹을 정상적으로 반환한다.")
+        void shouldReturnPriorityGroupsSuccessfully() {
+            // Given
+            List<AppointmentOption> sortedOptions = createTestOptions();
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability = createTestMemberAvailability();
+            Map<Long, String> memberNames = Map.of(savedMemberId, "사용자One");
+
+            // When
+            List<AppointmentPriorityGroupResponse> priorityGroups = priorityService
+                    .determineOptionPriority(sortedOptions, savedMemberId, memberAvailability, memberNames);
+
+            // Then
+            assertThat(priorityGroups).isNotEmpty();
+            assertThat(priorityGroups.get(0).priority()).isEqualTo(1L);
+            assertThat(priorityGroups.get(0).options()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("빈 옵션 리스트가 주어질 경우 빈 리스트 반환")
+        void shouldReturnEmptyListWhenOptionsAreEmpty() {
+            // Given
+            List<AppointmentOption> sortedOptions = List.of();
+            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability = createTestMemberAvailability();
+            Map<Long, String> memberNames = Map.of(savedMemberId, "사용자One");
+
+            // When
+            List<AppointmentPriorityGroupResponse> priorityGroups = priorityService
+                    .determineOptionPriority(sortedOptions, savedMemberId, memberAvailability, memberNames);
+
+            // Then
+            assertThat(priorityGroups).isEmpty();
+        }
+    }
+
+    private void initializeRepositories() {
+        likeRepository = new LikeRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        priorityService = new AppointmentOptionPriorityService(likeRepository, groupRepository);
+        appointmentRepository = new AppointmentRepositoryTest();
+        appointmentMemberRepository = new AppointmentMemberRepositoryTest();
+    }
+
+    private void initializeTestData() {
+        savedMemberId = createAndSaveMember("사용자One");
+        savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+        saveMemberGroup(savedMemberId, savedGroupId);
+    }
+
+    private List<AppointmentOption> createTestOptions() {
+        Appointment appointment = createAndSaveAppointment(savedMemberId, "팀미팅");
+        return List.of(
+                AppointmentOption.of(
+                        appointment,
+                        LocalDateTime.of(2024, 3, 15, 0, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 30)
+                )
+        );
+    }
+
+    private Map<Long, List<AppointmentMemberAvailableTime>> createTestMemberAvailability() {
+        AppointmentMember member = createAppointmentMember(savedMemberId);
+
+        return Map.of(
+                savedMemberId, List.of(
+                        AppointmentMemberAvailableTime.of(
+                                member,
+                                LocalDateTime.of(2024, 3, 15, 0, 0),
+                                LocalDateTime.of(2024, 3, 15, 10, 0),
+                                LocalDateTime.of(2024, 3, 15, 10, 30)
+                        )
+                )
+        );
+    }
+
+    private Appointment createAndSaveAppointment(Long memberId, String appointmentName) {
+        return appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(savedGroupId).orElseThrow(),
+                        memberId,
+                        appointmentName,
+                        60L,
+                        "중요",
+                        org.noostak.appointment.domain.vo.AppointmentStatus.PROGRESS
+                )
+        );
+    }
+
+    private AppointmentMember createAppointmentMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("멤버가 존재하지 않습니다."));
+        return AppointmentMember.of(AppointmentAvailability.AVAILABLE, createAndSaveAppointment(memberId, "팀미팅"), member);
+    }
+
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                org.noostak.group.domain.vo.GroupName.from(groupName),
+                org.noostak.group.domain.vo.GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private void saveMemberGroup(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        memberGroupRepository.save(MemberGroup.of(member, group));
+    }
+
+    private AppointmentMember createAppointmentMember(AppointmentAvailability availability, Long memberId, Long appointmentId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.MEMBER_NOT_FOUND));
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_NOT_FOUND));
+
+        return appointmentMemberRepository.save(AppointmentMember.of(availability, appointment, member));
+    }
+}

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentOptionPriorityServiceTest.java
@@ -1,6 +1,7 @@
 package org.noostak.appointment.application.recommendation;
 
 import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.recommendation.impl.AppointmentOptionPriorityServiceImpl;
 import org.noostak.appointment.common.exception.AppointmentErrorCode;
 import org.noostak.appointment.common.exception.AppointmentException;
 import org.noostak.appointment.domain.Appointment;
@@ -107,7 +108,7 @@ class AppointmentOptionPriorityServiceTest {
         groupRepository = new GroupRepositoryTest();
         memberRepository = new MemberRepositoryTest();
         memberGroupRepository = new MemberGroupRepositoryTest();
-        priorityService = new AppointmentOptionPriorityService(likeRepository, groupRepository);
+        priorityService = new AppointmentOptionPriorityServiceImpl(likeRepository, groupRepository);
         appointmentRepository = new AppointmentRepositoryTest();
         appointmentMemberRepository = new AppointmentMemberRepositoryTest();
     }

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryServiceTest.java
@@ -1,0 +1,188 @@
+package org.noostak.appointment.application.recommendation;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.domain.*;
+import org.noostak.appointmentmember.common.exception.*;
+import org.noostak.appointmentmember.domain.*;
+import org.noostak.appointmentmember.domain.repository.*;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.group.domain.*;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.*;
+import org.noostak.member.domain.vo.*;
+import org.noostak.membergroup.*;
+import org.noostak.membergroup.domain.MemberGroup;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+class AppointmentParticipantQueryServiceTest {
+
+    private AppointmentMemberRepositoryTest appointmentMemberRepository;
+    private AppointmentMemberAvailableTimesRepositoryTest appointmentMemberAvailableTimesRepository;
+    private AppointmentRepositoryTest appointmentRepository;
+    private MemberRepositoryTest memberRepository;
+    private MemberGroupRepositoryTest memberGroupRepository;
+    private GroupRepositoryTest groupRepository;
+    private AppointmentHostSelectionTimeRepositoryTest appointmentHostSelectionTimeRepository;
+
+    private AppointmentParticipantQueryService participantQueryService;
+
+    private Long savedMemberId;
+    private Long savedGroupId;
+    private Long savedAppointmentId;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        appointmentMemberAvailableTimesRepository.deleteAll();
+        appointmentMemberRepository.deleteAll();
+        appointmentRepository.deleteAll();
+        memberRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("약속 ID로 참여자 이름을 정상적으로 조회한다.")
+        void shouldFindParticipantNamesByAppointmentId() {
+            // When
+            Map<Long, String> participantNames = participantQueryService.findParticipantNamesByAppointmentId(savedAppointmentId);
+
+            // Then
+            assertThat(participantNames).isNotEmpty();
+            assertThat(participantNames).containsKey(savedMemberId);
+            assertThat(participantNames.get(savedMemberId)).isEqualTo("사용자One");
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("해당 약속 ID의 참여자가 없을 경우 빈 맵 반환")
+        void shouldReturnEmptyMapWhenNoParticipantsFound() {
+            // Given
+            Long invalidAppointmentId = 999L;
+
+            // When
+            Map<Long, String> participantNames = participantQueryService.findParticipantNamesByAppointmentId(invalidAppointmentId);
+
+            // Then
+            assertThat(participantNames).isEmpty();
+        }
+    }
+
+    private void initializeRepositories() {
+        appointmentMemberRepository = new AppointmentMemberRepositoryTest();
+        appointmentMemberAvailableTimesRepository = new AppointmentMemberAvailableTimesRepositoryTest();
+        appointmentRepository = new AppointmentRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        appointmentHostSelectionTimeRepository = new AppointmentHostSelectionTimeRepositoryTest();
+
+        participantQueryService = new AppointmentParticipantQueryService(appointmentMemberAvailableTimesRepository);
+    }
+
+    private void initializeTestData() {
+        initializeMemberAndGroup();
+        initializeAppointmentData();
+    }
+
+    private void initializeMemberAndGroup() {
+        savedMemberId = createAndSaveMember("사용자One");
+        savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+        saveMemberGroup(savedMemberId, savedGroupId);
+    }
+
+    private void initializeAppointmentData() {
+        savedAppointmentId = createAndSaveAppointment(savedMemberId, "팀미팅");
+        saveAppointmentMember(AppointmentAvailability.AVAILABLE, savedMemberId, savedAppointmentId);
+    }
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                org.noostak.group.domain.vo.GroupName.from(groupName),
+                org.noostak.group.domain.vo.GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private void saveMemberGroup(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        Group group = groupRepository.findById(groupId).orElseThrow();
+        memberGroupRepository.save(MemberGroup.of(member, group));
+    }
+
+    private Long createAndSaveAppointment(Long memberId, String appointmentName) {
+        Appointment appointment = appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(savedGroupId).orElseThrow(),
+                        memberId,
+                        appointmentName,
+                        60L,
+                        "중요",
+                        org.noostak.appointment.domain.vo.AppointmentStatus.PROGRESS
+                )
+        );
+        return appointment.getId();
+    }
+
+    private void saveAppointmentMember(AppointmentAvailability availability, Long memberId, Long appointmentId) {
+        AppointmentMember appointmentMember = createAppointmentMember(availability, memberId, appointmentId);
+        List<AppointmentMemberAvailableTime> availableTimes = createAvailableTimes(appointmentMember);
+
+        appointmentMemberAvailableTimesRepository.saveAll(availableTimes);
+        appointmentMember.updateAvailableTimes(availableTimes);
+    }
+
+    private AppointmentMember createAppointmentMember(AppointmentAvailability availability, Long memberId, Long appointmentId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AppointmentMemberException(AppointmentMemberErrorCode.APPOINTMENT_MEMBER_NOT_FOUND));
+        Appointment appointment = appointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new AppointmentMemberException(AppointmentMemberErrorCode.APPOINTMENT_NOT_FOUND));
+
+        return appointmentMemberRepository.save(AppointmentMember.of(availability, appointment, member));
+    }
+
+    private List<AppointmentMemberAvailableTime> createAvailableTimes(AppointmentMember appointmentMember) {
+        return List.of(
+                AppointmentMemberAvailableTime.of(appointmentMember,
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 30)),
+
+                AppointmentMemberAvailableTime.of(appointmentMember,
+                        LocalDateTime.of(2024, 3, 15, 11, 0),
+                        LocalDateTime.of(2024, 3, 15, 11, 0),
+                        LocalDateTime.of(2024, 3, 15, 11, 30))
+        );
+    }
+}

--- a/src/test/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryServiceTest.java
+++ b/src/test/java/org/noostak/appointment/application/recommendation/AppointmentParticipantQueryServiceTest.java
@@ -1,6 +1,7 @@
 package org.noostak.appointment.application.recommendation;
 
 import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.recommendation.impl.AppointmentParticipantQueryServiceImpl;
 import org.noostak.appointment.domain.*;
 import org.noostak.appointmentmember.common.exception.*;
 import org.noostak.appointmentmember.domain.*;
@@ -95,7 +96,7 @@ class AppointmentParticipantQueryServiceTest {
         memberGroupRepository = new MemberGroupRepositoryTest();
         appointmentHostSelectionTimeRepository = new AppointmentHostSelectionTimeRepositoryTest();
 
-        participantQueryService = new AppointmentParticipantQueryService(appointmentMemberAvailableTimesRepository);
+        participantQueryService = new AppointmentParticipantQueryServiceImpl(appointmentMemberAvailableTimesRepository);
     }
 
     private void initializeTestData() {

--- a/src/test/java/org/noostak/appointment/domain/AppointmentRepositoryTest.java
+++ b/src/test/java/org/noostak/appointment/domain/AppointmentRepositoryTest.java
@@ -6,38 +6,45 @@ import org.springframework.data.repository.query.FluentQuery;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class AppointmentRepositoryTest implements AppointmentRepository {
+public class AppointmentRepositoryTest implements AppointmentRepository, AppointmentRepositoryCustom {
 
     private final List<Appointment> appointments = new ArrayList<>();
     private final AtomicLong idGenerator = new AtomicLong(1);
 
     @Override
     public Appointment save(Appointment entity) {
-        try {
-            if (entity.getId() == null) {
-                var idField = Appointment.class.getDeclaredField("id");
-                idField.setAccessible(true);
-                idField.set(entity, idGenerator.getAndIncrement());
-            }
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("[ERROR] 'appointmentId' 필드에 접근할 수 없습니다.", e);
+        if (entity.getId() == null) {
+            setEntityId(entity);
         }
         appointments.add(entity);
         return entity;
     }
 
     @Override
-    public <S extends Appointment> List<S> saveAll(Iterable<S> entities) {
-        List<S> result = new ArrayList<>();
-        for (S entity : entities) {
-            Appointment savedEntity = save(entity);
-            result.add((S) savedEntity);
-        }
-        return result;
+    public List<Appointment> findAllByGroupId(Long groupId) {
+        return appointments.stream()
+                .filter(appointment -> {
+                    boolean matches = appointment.getGroup().getId().equals(groupId);
+                    return matches;
+                })
+                .sorted((a1, a2) -> {
+                    return Comparator.comparing(Appointment::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())).reversed()
+                            .compare(a1, a2);
+                })
+                .collect(Collectors.toList());
     }
 
+    @Override
+    public <S extends Appointment> List<S> saveAll(Iterable<S> entities) {
+        List<S> savedEntities = new ArrayList<>();
+        for (S entity : entities) {
+            savedEntities.add((S) save(entity));
+        }
+        return savedEntities;
+    }
 
     @Override
     public Optional<Appointment> findById(Long id) {
@@ -52,6 +59,11 @@ public class AppointmentRepositoryTest implements AppointmentRepository {
     }
 
     @Override
+    public List<Appointment> findAllById(Iterable<Long> longs) {
+        return List.of();
+    }
+
+    @Override
     public void deleteAll() {
         appointments.clear();
     }
@@ -63,24 +75,22 @@ public class AppointmentRepositoryTest implements AppointmentRepository {
 
     @Override
     public void delete(Appointment entity) {
-        appointments.remove(entity);
+
     }
 
     @Override
-    public void deleteAllById(Iterable<? extends Long> ids) {
-        StreamSupport.stream(ids.spliterator(), false)
-                .forEach(this::deleteById);
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
     }
 
     @Override
     public void deleteAll(Iterable<? extends Appointment> entities) {
-        StreamSupport.stream(entities.spliterator(), false)
-                .forEach(appointments::remove);
+
     }
 
     @Override
     public boolean existsById(Long id) {
-        return appointments.stream().anyMatch(appointment -> appointment.getId().equals(id));
+        return findById(id).isPresent();
     }
 
     @Override
@@ -88,72 +98,61 @@ public class AppointmentRepositoryTest implements AppointmentRepository {
         return appointments.size();
     }
 
-    @Override
-    public List<Appointment> findAllById(Iterable<Long> ids) {
-        List<Appointment> result = new ArrayList<>();
-        StreamSupport.stream(ids.spliterator(), false)
-                .map(this::findById)
-                .flatMap(Optional::stream)
-                .forEach(result::add);
-        return result;
+    /**
+     * 엔터티 ID를 설정하는 메서드 (리플렉션 사용)
+     */
+    private void setEntityId(Appointment entity) {
+        try {
+            var idField = Appointment.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, idGenerator.getAndIncrement());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("[ERROR] 'appointmentId' 필드에 접근할 수 없습니다.", e);
+        }
     }
 
     @Override
-    public List<Appointment> findAll(Sort sort) {
-        return new ArrayList<>(appointments);
-    }
+    public void flush() {
 
-    @Override
-    public Page<Appointment> findAll(Pageable pageable) {
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), appointments.size());
-        List<Appointment> pageContent = appointments.subList(start, end);
-        return new PageImpl<>(pageContent, pageable, appointments.size());
     }
-
     @Override
-    public void flush() {}
+    public <S extends Appointment> S saveAndFlush(S entity) {
+        return null;
+    }
 
     @Override
     public <S extends Appointment> List<S> saveAllAndFlush(Iterable<S> entities) {
-        return saveAll(entities);
-    }
-
-    @Override
-    public Appointment saveAndFlush(Appointment entity) {
-        return save(entity);
+        return List.of();
     }
 
     @Override
     public void deleteAllInBatch(Iterable<Appointment> entities) {
-        StreamSupport.stream(entities.spliterator(), false)
-                .forEach(appointments::remove);
+
     }
 
     @Override
-    public void deleteAllByIdInBatch(Iterable<Long> ids) {
-        StreamSupport.stream(ids.spliterator(), false)
-                .forEach(this::deleteById);
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
     }
 
     @Override
     public void deleteAllInBatch() {
-        appointments.clear();
+
     }
 
     @Override
-    public Appointment getOne(Long id) {
-        return findById(id).orElse(null);
+    public Appointment getOne(Long aLong) {
+        return null;
     }
 
     @Override
-    public Appointment getById(Long id) {
-        return findById(id).orElse(null);
+    public Appointment getById(Long aLong) {
+        return null;
     }
 
     @Override
-    public Appointment getReferenceById(Long id) {
-        return findById(id).orElse(null);
+    public Appointment getReferenceById(Long aLong) {
+        return null;
     }
 
     @Override
@@ -173,7 +172,7 @@ public class AppointmentRepositoryTest implements AppointmentRepository {
 
     @Override
     public <S extends Appointment> Page<S> findAll(Example<S> example, Pageable pageable) {
-        return Page.empty();
+        return null;
     }
 
     @Override
@@ -188,6 +187,16 @@ public class AppointmentRepositoryTest implements AppointmentRepository {
 
     @Override
     public <S extends Appointment, R> R findBy(Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public List<Appointment> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<Appointment> findAll(Pageable pageable) {
         return null;
     }
 }

--- a/src/test/java/org/noostak/appointmentmember/domain/repository/AppointmentMemberRepositoryTest.java
+++ b/src/test/java/org/noostak/appointmentmember/domain/repository/AppointmentMemberRepositoryTest.java
@@ -182,4 +182,5 @@ public class AppointmentMemberRepositoryTest implements AppointmentMemberReposit
     public Page<AppointmentMember> findAll(Pageable pageable) {
         return null;
     }
+
 }

--- a/src/test/java/org/noostak/appointmentoption/domain/AppointmentOptionRepositoryTest.java
+++ b/src/test/java/org/noostak/appointmentoption/domain/AppointmentOptionRepositoryTest.java
@@ -42,10 +42,14 @@ public class AppointmentOptionRepositoryTest implements AppointmentOptionReposit
 
     @Override
     public List<AppointmentOption> findAllById(Iterable<Long> ids) {
+        Set<Long> idSet = new HashSet<>();
+        ids.forEach(idSet::add);
+
         return appointmentOptions.stream()
-                .filter(option -> ids.iterator().hasNext() && ids.iterator().next().equals(option.getId()))
+                .filter(option -> idSet.contains(option.getId()))
                 .collect(Collectors.toList());
     }
+
 
     @Override
     public void deleteAll() {

--- a/src/test/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentServiceImplTest.java
+++ b/src/test/java/org/noostak/group/application/ongoing/GroupOngoingAppointmentServiceImplTest.java
@@ -1,0 +1,205 @@
+package org.noostak.group.application.ongoing;
+
+import org.junit.jupiter.api.*;
+import org.noostak.appointment.application.recommendation.AppointmentRecommendationFacade;
+import org.noostak.appointment.domain.*;
+import org.noostak.appointment.domain.vo.AppointmentStatus;
+import org.noostak.appointment.dto.response.*;
+import org.noostak.appointmentmember.domain.*;
+import org.noostak.appointmentmember.domain.repository.*;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.group.domain.*;
+import org.noostak.group.domain.vo.GroupName;
+import org.noostak.group.domain.vo.GroupProfileImageKey;
+import org.noostak.group.dto.response.ongoing.*;
+import org.noostak.infra.S3Service;
+import org.noostak.member.MemberRepositoryTest;
+import org.noostak.member.domain.*;
+import org.noostak.member.domain.vo.*;
+import org.noostak.membergroup.MemberGroupRepositoryTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GroupOngoingAppointmentServiceImplTest {
+
+    private AppointmentRecommendationFacade recommendationFacade;
+    private final S3Service s3Service = mock(S3Service.class);
+    private GroupOngoingAppointmentServiceImpl service;
+
+    private AppointmentRepositoryTest appointmentRepository;
+    private GroupRepositoryTest groupRepository;
+    private MemberRepositoryTest memberRepository;
+    private MemberGroupRepositoryTest memberGroupRepository;
+    private AppointmentMemberRepositoryTest appointmentMemberRepository;
+    private AppointmentMemberAvailableTimesRepositoryTest availableTimesRepository;
+    private AppointmentHostSelectionTimeRepositoryTest hostSelectionTimeRepository;
+
+    private Long savedMemberId;
+    private Long savedGroupId;
+
+    @BeforeEach
+    void setUp() {
+        initializeRepositories();
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        availableTimesRepository.deleteAll();
+        appointmentMemberRepository.deleteAll();
+        appointmentRepository.deleteAll();
+        memberRepository.deleteAll();
+        groupRepository.deleteAll();
+        memberGroupRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("성공 케이스 검증")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("그룹 내 모든 약속에서 가용 인원이 가장 많은 옵션을 반환한다.")
+        void shouldReturnBestAvailableOptionForEachAppointment() {
+            // Given
+            Appointment appointment1 = createAndSaveAppointment("약속1");
+            Appointment appointment2 = createAndSaveAppointment("약속2");
+
+            saveAppointmentMember(AppointmentAvailability.AVAILABLE, savedMemberId, appointment1.getId());
+            saveAppointmentMember(AppointmentAvailability.AVAILABLE, savedMemberId, appointment2.getId());
+
+            mockRecommendedOptions(appointment1, 5L);
+            mockRecommendedOptions(appointment2, 8L);
+
+            // When
+            GroupOngoingAppointmentsResponse response = service.getGroupOngoingAppointments(savedMemberId, savedGroupId);
+
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.ongoingAppointments()).hasSize(2);
+            assertThat(response.ongoingAppointments().get(0).availableGroupMemberCount()).isEqualTo(5L);
+            assertThat(response.ongoingAppointments().get(1).availableGroupMemberCount()).isEqualTo(8L);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스 검증")
+    class FailureCases {
+
+        @Test
+        @DisplayName("추천 옵션이 존재하지 않으면 빈 응답을 반환한다.")
+        void shouldReturnEmptyResponseWhenNoRecommendedOptionsExist() {
+            // Given
+            Appointment appointment = createAndSaveAppointment("추천 없음");
+            when(recommendationFacade.getRecommendedOptions(savedMemberId, appointment.getId(), appointment))
+                    .thenReturn(List.of());
+
+            // When
+            GroupOngoingAppointmentsResponse response = service.getGroupOngoingAppointments(savedMemberId, savedGroupId);
+
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.ongoingAppointments()).isEmpty();
+        }
+    }
+
+    private void initializeRepositories() {
+        appointmentRepository = new AppointmentRepositoryTest();
+        groupRepository = new GroupRepositoryTest();
+        memberRepository = new MemberRepositoryTest();
+        memberGroupRepository = new MemberGroupRepositoryTest();
+        appointmentMemberRepository = new AppointmentMemberRepositoryTest();
+        availableTimesRepository = new AppointmentMemberAvailableTimesRepositoryTest();
+        hostSelectionTimeRepository = new AppointmentHostSelectionTimeRepositoryTest();
+
+        recommendationFacade = mock(AppointmentRecommendationFacade.class);
+        service = new GroupOngoingAppointmentServiceImpl(recommendationFacade, groupRepository, appointmentRepository, s3Service);
+    }
+
+    private void initializeTestData() {
+        savedMemberId = createAndSaveMember("사용자One");
+        savedGroupId = createAndSaveGroup(savedMemberId, "테스트그룹");
+    }
+
+    private Long createAndSaveMember(String name) {
+        Member member = memberRepository.save(Member.of(
+                MemberName.from(name),
+                MemberProfileImageKey.from("profile-key"),
+                AuthType.GOOGLE,
+                AuthId.from("auth-id"),
+                "refresh-token"
+        ));
+        return member.getId();
+    }
+
+    private Long createAndSaveGroup(Long memberId, String groupName) {
+        Group group = groupRepository.save(Group.of(
+                memberId,
+                GroupName.from(groupName),
+                GroupProfileImageKey.from("group-image-key"),
+                "INVITE"
+        ));
+        return group.getId();
+    }
+
+    private Appointment createAndSaveAppointment(String name) {
+        return appointmentRepository.save(
+                Appointment.of(
+                        groupRepository.findById(savedGroupId).orElseThrow(),
+                        savedMemberId,
+                        name,
+                        60L,
+                        "중요",
+                        AppointmentStatus.PROGRESS
+                )
+        );
+    }
+
+    private void saveAppointmentMember(AppointmentAvailability availability, Long memberId, Long appointmentId) {
+        Appointment appointment = appointmentRepository.findById(appointmentId).orElseThrow();
+        Member member = memberRepository.findById(memberId).orElseThrow();
+
+        AppointmentMember appointmentMember = AppointmentMember.of(availability, appointment, member);
+        appointmentMemberRepository.save(appointmentMember);
+
+        availableTimesRepository.saveAll(List.of(
+                AppointmentMemberAvailableTime.of(
+                        appointmentMember,
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 30)
+                )
+        ));
+    }
+
+    private void mockRecommendedOptions(Appointment appointment, Long availableMemberCount) {
+        AppointmentOptionResponse optionResponse = AppointmentOptionResponse.of(
+                1L,
+                10L,
+                false,
+                20L,
+                availableMemberCount,
+                AppointmentOptionTimeResponse.of(
+                        LocalDateTime.of(2024, 3, 15, 10, 0),
+                        LocalDateTime.of(2024, 3, 15, 10, 30),
+                        LocalDateTime.of(2024, 3, 15, 11, 0)
+                ),
+                AppointmentMyInfoResponse.of("AVAILABLE", 1L, "사용자1"),
+                AvailableFriendsResponse.of(3L, List.of("친구1", "친구2", "친구3")),
+                UnavailableFriendsResponse.of(2L, List.of("친구4", "친구5"))
+        );
+
+        AppointmentPriorityGroupResponse priorityGroup = AppointmentPriorityGroupResponse.of(
+                1L,
+                List.of(optionResponse)
+        );
+
+        List<AppointmentPriorityGroupResponse> recommendedOptions = List.of(priorityGroup);
+
+        when(recommendationFacade.getRecommendedOptions(savedMemberId, appointment.getId(), appointment))
+                .thenReturn(recommendedOptions);
+    }
+}

--- a/src/test/java/org/noostak/likes/domain/LikeRepositoryTest.java
+++ b/src/test/java/org/noostak/likes/domain/LikeRepositoryTest.java
@@ -1,0 +1,203 @@
+package org.noostak.likes.domain;
+
+import org.springframework.data.domain.*;
+import org.springframework.data.repository.query.FluentQuery;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class LikeRepositoryTest implements LikeRepository {
+
+    private final List<Like> likes = new ArrayList<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public Like save(Like entity) {
+        try {
+            if (entity.getId() == null) {
+                var idField = Like.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(entity, idGenerator.getAndIncrement());
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("[ERROR] 'id' 필드에 접근할 수 없습니다.", e);
+        }
+        likes.add(entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends Like> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            Like savedEntity = save(entity);
+            result.add((S) savedEntity);
+        }
+        return result;
+    }
+
+    @Override
+    public Optional<Like> findById(Long id) {
+        return likes.stream()
+                .filter(like -> like.getId().equals(id))
+                .findFirst();
+    }
+
+    @Override
+    public List<Like> findAll() {
+        return new ArrayList<>(likes);
+    }
+
+    @Override
+    public void deleteAll() {
+        likes.clear();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        likes.removeIf(like -> like.getId().equals(id));
+    }
+
+    @Override
+    public void delete(Like entity) {
+        likes.remove(entity);
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Like> entities) {
+
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return likes.stream().anyMatch(like -> like.getId().equals(id));
+    }
+
+    @Override
+    public long count() {
+        return likes.size();
+    }
+
+    @Override
+    public List<Like> findAllById(Iterable<Long> ids) {
+        return StreamSupport.stream(ids.spliterator(), false)
+                .map(this::findById)
+                .flatMap(Optional::stream)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Like> findAll(Sort sort) {
+        return new ArrayList<>(likes);
+    }
+
+    @Override
+    public Page<Like> findAll(Pageable pageable) {
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), likes.size());
+        List<Like> pageContent = likes.subList(start, end);
+        return new PageImpl<>(pageContent, pageable, likes.size());
+    }
+
+    @Override
+    public Long countByAppointmentOptionId(Long appointmentOptionId) {
+        return likes.stream()
+                .filter(like -> like.getAppointmentOption().getId().equals(appointmentOptionId))
+                .count();
+    }
+
+    @Override
+    public boolean existsByAppointmentOptionIdAndAppointmentMemberId(Long appointmentOptionId, Long appointmentMemberId) {
+        return likes.stream()
+                .anyMatch(like -> like.getAppointmentOption().getId().equals(appointmentOptionId) &&
+                        like.getAppointmentMember().getId().equals(appointmentMemberId));
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Like> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Like> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Like> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Like getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Like getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Like getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Like> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Like> List<S> findAll(Example<S> example) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Like> List<S> findAll(Example<S> example, Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Like> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Like> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Like> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Like, R> R findBy(Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 진행 중인 약속들 조회 API를 구현하였습니다.

# 🛠️ What’s been done?
- **주요 변경사항:**
  - 추천된 약속들 중, 참여 인원이 많은 약속을 대표로 선정하여 진행 중인 약속들을 보여주는 기능을 추가하였습니다.
  - 기존 약속 추천 서비스 로직을 인터페이스로 분리하여 재사용성을 높였습니다.

# 🧪 Testing Details
- **테스트 코드 및 결과:**
  - 진행 중인 약속들 조회 API의 동작을 검증하는 테스트 코드를 작성하였습니다.
  - 기존 테스트와 함께 실행한 결과, 모든 테스트가 정상적으로 동작함을 확인하였습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - 기존 약속 추천 비즈니스 로직을 인터페이스로 분리하여 사용했으나, 가용 인원과 시간을 가져올 때 일부 불필요한 로직이 포함되어 있습니다.
  - 마감 기한이 얼마 남지 않아 현재는 DTO에서 필요한 데이터를 추출하는 방식으로 처리하였으며, 안정화 이후에는 필요한 데이터만 포함된 DTO로 변경할 계획입니다.
  - 이에 대한 의견이 궁금합니다.
  - 약속 참여 인원 정보를 엔티티에 포함하면 API에서 별도로 계산할 필요가 없어질 것으로 보이는데, 이에 대한 의견도 부탁드립니다.

# 🎯 Related Issues
- #90