### PR TITLE
[✨feat] 마이페이지 - 로그아웃 및 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/org/noostak/auth/api/OauthController.java
+++ b/src/main/java/org/noostak/auth/api/OauthController.java
@@ -162,4 +162,25 @@ public class OauthController {
         throw new AuthException(AuthErrorCode.INVALID_TOKEN);
     }
 
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request){
+        String givenAccessToken = request.getHeader("Authorization");
+        givenAccessToken = JwtToken.extractToken(givenAccessToken);
+
+        // 토큰 provider 찾기
+        for(AuthType authType : AuthType.values()){
+            OauthService oauthService = oauthServiceFactory.getService(authType);
+
+            try {
+                oauthService.logout(givenAccessToken);
+                return ResponseEntity.ok((SuccessResponse.of(AuthSuccessCode.LOGOUT_COMPLETED)));
+            }catch (ExternalApiException | RestClientException e){
+                GlobalLogger.warn(AuthErrorCode.INVALID_TOKEN.getMessage());
+            }
+        }
+
+        // 통과하지 못한다면 유효한 토큰이 아닌 것으로 판단
+        throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+    }
 }

--- a/src/main/java/org/noostak/auth/application/GoogleApi.java
+++ b/src/main/java/org/noostak/auth/application/GoogleApi.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 public enum GoogleApi {
     TOKEN_REQUEST("https://oauth2.googleapis.com/token"),
     USER_INFO("https://www.googleapis.com/oauth2/v2/userinfo"),
-    LOGOUT("https://kauth.kakao.com/oauth/logout"),
     UNLINK("https://oauth2.googleapis.com/revoke")
 
     ;

--- a/src/main/java/org/noostak/auth/application/GoogleApi.java
+++ b/src/main/java/org/noostak/auth/application/GoogleApi.java
@@ -8,7 +8,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GoogleApi {
     TOKEN_REQUEST("https://oauth2.googleapis.com/token"),
-    USER_INFO("https://www.googleapis.com/oauth2/v2/userinfo")
+    USER_INFO("https://www.googleapis.com/oauth2/v2/userinfo"),
+    LOGOUT("https://kauth.kakao.com/oauth/logout"),
+    UNLINK("https://oauth2.googleapis.com/revoke")
+
     ;
 
     private final String url;

--- a/src/main/java/org/noostak/auth/application/GoogleServiceImpl.java
+++ b/src/main/java/org/noostak/auth/application/GoogleServiceImpl.java
@@ -65,6 +65,23 @@ public class GoogleServiceImpl implements GoogleService{
         return AuthId.from(response.getId());
     }
 
+    @Override
+    public void logout(String accessToken) {
+        String url = KaKaoApi.LOGOUT.getUrl();
+    }
+
+    @Override
+    public void unlink(String accessToken) {
+        String url = GoogleApi.UNLINK.getUrl();
+
+        HttpHeaders headers = makeAuthorizationBearerTokenHeader(accessToken);
+
+        GoogleUnlinkResponse response =
+                restClient.postRequest(url, headers, GoogleUnlinkResponse.class);
+
+        response.validate();
+    }
+
     public HttpHeaders makeAuthorizationBearerTokenHeader(String token){
         HttpHeaders headers = new HttpHeaders();
 

--- a/src/main/java/org/noostak/auth/application/GoogleServiceImpl.java
+++ b/src/main/java/org/noostak/auth/application/GoogleServiceImpl.java
@@ -67,7 +67,7 @@ public class GoogleServiceImpl implements GoogleService{
 
     @Override
     public void logout(String accessToken) {
-        String url = KaKaoApi.LOGOUT.getUrl();
+        // 별도로 처리 해줄 로직 없음
     }
 
     @Override

--- a/src/main/java/org/noostak/auth/application/KaKaoApi.java
+++ b/src/main/java/org/noostak/auth/application/KaKaoApi.java
@@ -8,7 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum KaKaoApi {
     TOKEN_REQUEST("https://kauth.kakao.com/oauth/token"),
-    USER_INFO("https://kapi.kakao.com/v2/user/me")
+    USER_INFO("https://kapi.kakao.com/v2/user/me"),
+    LOGOUT("https://kauth.kakao.com/oauth/logout"),
+    UNLINK("https://kauth.kakao.com/oauth/unlink"),
     ;
 
     private final String url;

--- a/src/main/java/org/noostak/auth/application/KakaoServiceImpl.java
+++ b/src/main/java/org/noostak/auth/application/KakaoServiceImpl.java
@@ -66,6 +66,23 @@ public class KakaoServiceImpl implements KakaoService{
         return AuthId.from(response.getId());
     }
 
+    @Override
+    public void logout(String accessToken) {
+        String url = KaKaoApi.LOGOUT.getUrl();
+    }
+
+    @Override
+    public void unlink(String accessToken) {
+        String url = KaKaoApi.UNLINK.getUrl();
+
+        HttpHeaders headers = makeAuthorizationBearerTokenHeader(accessToken);
+
+        KakaoUnlinkResponse response =
+                restClient.postRequest(url, headers, KakaoUnlinkResponse.class);
+
+        response.validate();
+    }
+
     public HttpHeaders makeAuthorizationBearerTokenHeader(String token){
         HttpHeaders headers = new HttpHeaders();
 

--- a/src/main/java/org/noostak/auth/application/KakaoServiceImpl.java
+++ b/src/main/java/org/noostak/auth/application/KakaoServiceImpl.java
@@ -14,10 +14,11 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class KakaoServiceImpl implements KakaoService{
+public class KakaoServiceImpl implements KakaoService {
 
     private final KakaoTokenRequestFactory kakaoTokenRequestFactory;
     private final RestClient restClient;
+
     @Override
     public JwtToken requestAccessToken(String givenRefreshToken) throws ExternalApiException {
         String url = KaKaoApi.TOKEN_REQUEST.getUrl();
@@ -49,7 +50,7 @@ public class KakaoServiceImpl implements KakaoService{
 
         response.validate();
 
-        return JwtTokenProvider.createToken(response.getAccessToken(),response.getRefreshToken());
+        return JwtTokenProvider.createToken(response.getAccessToken(), response.getRefreshToken());
     }
 
     @Override
@@ -69,6 +70,17 @@ public class KakaoServiceImpl implements KakaoService{
     @Override
     public void logout(String accessToken) {
         String url = KaKaoApi.LOGOUT.getUrl();
+
+        HttpHeaders headers = makeAuthorizationBearerTokenHeader(accessToken);
+
+        KakaoLogoutRequest request = kakaoTokenRequestFactory.createLogoutRequest();
+
+        KakaoLogoutResponse response = restClient.getRequest(url,
+                headers,
+                request.getUrlEncodedParams(),
+                KakaoLogoutResponse.class);
+
+        response.validate();
     }
 
     @Override
@@ -83,10 +95,10 @@ public class KakaoServiceImpl implements KakaoService{
         response.validate();
     }
 
-    public HttpHeaders makeAuthorizationBearerTokenHeader(String token){
+    public HttpHeaders makeAuthorizationBearerTokenHeader(String token) {
         HttpHeaders headers = new HttpHeaders();
 
-        if(token == null || token.isEmpty() || token.isBlank()){
+        if (token == null || token.isEmpty() || token.isBlank()) {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
 

--- a/src/main/java/org/noostak/auth/application/KakaoTokenRequestFactory.java
+++ b/src/main/java/org/noostak/auth/application/KakaoTokenRequestFactory.java
@@ -1,6 +1,7 @@
 package org.noostak.auth.application;
 
 import org.noostak.auth.dto.KakaoAccessTokenRequest;
+import org.noostak.auth.dto.KakaoLogoutRequest;
 import org.noostak.auth.dto.KakaoTokenRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,11 +19,19 @@ public class KakaoTokenRequestFactory {
     @Value("${oauth-property.kakao.client_secret}")
     private final String clientSecret;
 
+    @Value("${oauth-property.kakao.logout_redirect_uri}")
+    private final String logoutRedirectUri;
 
-    public KakaoTokenRequestFactory(String clientId, String redirectUri, String clientSecret) {
+
+    public KakaoTokenRequestFactory(String clientId, String redirectUri, String clientSecret, String logoutRedirectUri) {
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.clientSecret = clientSecret;
+        this.logoutRedirectUri = logoutRedirectUri;
+    }
+
+    public KakaoLogoutRequest createLogoutRequest(){
+        return KakaoLogoutRequest.of(clientId,logoutRedirectUri);
     }
 
     public KakaoTokenRequest createRequest(String code) {

--- a/src/main/java/org/noostak/auth/application/OauthService.java
+++ b/src/main/java/org/noostak/auth/application/OauthService.java
@@ -12,4 +12,7 @@ public interface OauthService {
 
     AuthId verify(String accessToken); // 로그인 처리
 
+    void logout(String accessToken); // 로그 아웃
+
+    void unlink(String accessToken); // 연결 끊기
 }

--- a/src/main/java/org/noostak/auth/application/RestClient.java
+++ b/src/main/java/org/noostak/auth/application/RestClient.java
@@ -94,6 +94,18 @@ public class RestClient {
         }
     }
 
+    public <T> T getRequest(String url, HttpHeaders headers, String urlParams, Class<T> responseType) {
+        try {
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            HttpEntity<String> entity = new HttpEntity<>(urlParams, headers);
+
+            T response = restTemplate.exchange(url, HttpMethod.GET, entity, responseType).getBody();
+            return validate(response);
+        } catch (Exception e) {
+            throw new RestClientException(RestClientErrorCode.REST_CLIENT_ERROR, e.getMessage());
+        }
+    }
+
     private <T> T validate(T response){
         validateIsNull(response);
 

--- a/src/main/java/org/noostak/auth/application/RestClient.java
+++ b/src/main/java/org/noostak/auth/application/RestClient.java
@@ -84,6 +84,16 @@ public class RestClient {
         }
     }
 
+    public <T, R> T getRequest(String url, HttpHeaders headers, R request, Class<T> responseType) {
+        try {
+            HttpEntity<R> entity = new HttpEntity<>(request, headers);
+            T response = restTemplate.exchange(url, HttpMethod.GET, entity, responseType).getBody();
+            return validate(response);
+        } catch (Exception e) {
+            throw new RestClientException(RestClientErrorCode.REST_CLIENT_ERROR, e.getMessage());
+        }
+    }
+
     private <T> T validate(T response){
         validateIsNull(response);
 

--- a/src/main/java/org/noostak/auth/common/success/AuthSuccessCode.java
+++ b/src/main/java/org/noostak/auth/common/success/AuthSuccessCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthSuccessCode implements SuccessCode {
     SIGN_UP_COMPLETED(HttpStatus.CREATED, "회원가입이 성공적으로 완료 되었습니다."),
     SIGN_IN_COMPLETED(HttpStatus.OK, "소셜 로그인에 성공했습니다."),
+    LOGOUT_COMPLETED(HttpStatus.OK, "로그아웃에 성공하였습니다."),
+    UNLINK_COMPLETED(HttpStatus.OK, "회원 탈퇴에 성공하였습니다."),
     AUTHORIZE_COMPLETED(HttpStatus.OK, "소셜 사용자 인증을 성공하였습니다."),
     TOKEN_REISSUE_COMPLETED(HttpStatus.OK, "토큰 재발급에 성공하였습니다.")
     ;

--- a/src/main/java/org/noostak/auth/domain/AuthInfo.java
+++ b/src/main/java/org/noostak/auth/domain/AuthInfo.java
@@ -30,7 +30,7 @@ public class AuthInfo {
     @AttributeOverride(name = "token", column = @Column(name = "refresh_token"))
     private RefreshToken refreshToken;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/org/noostak/auth/dto/GoogleUnlinkResponse.java
+++ b/src/main/java/org/noostak/auth/dto/GoogleUnlinkResponse.java
@@ -1,0 +1,26 @@
+package org.noostak.auth.dto;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.noostak.auth.common.exception.KakaoApiErrorCode;
+import org.noostak.auth.common.exception.KakaoApiException;
+
+
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GoogleUnlinkResponse {
+    private String error;
+    private String errorDescription;
+    private String errorCode;
+
+    public void validate(){
+        if(error!= null){
+            throw new KakaoApiException(KakaoApiErrorCode.KAKAO_API_ERROR, errorDescription);
+        }
+    }
+}
+

--- a/src/main/java/org/noostak/auth/dto/KakaoLogoutRequest.java
+++ b/src/main/java/org/noostak/auth/dto/KakaoLogoutRequest.java
@@ -1,0 +1,39 @@
+package org.noostak.auth.dto;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@ToString
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoLogoutRequest {
+
+    private String clientId;
+
+    private String logoutRedirectUri;
+
+
+    private KakaoLogoutRequest(String clientId, String logoutRedirectUri) {
+        this.clientId = clientId;
+        this.logoutRedirectUri= logoutRedirectUri;
+    }
+
+    public static KakaoLogoutRequest of(String clientId, String logoutRedirectUri){
+        return new KakaoLogoutRequest(clientId,logoutRedirectUri);
+    }
+
+    public String getUrlEncodedParams() {
+        StringBuilder params = new StringBuilder();
+
+        params.append("&client_id=").append(URLEncoder.encode(clientId, StandardCharsets.UTF_8));
+        params.append("&logout_redirect_uri=").append(URLEncoder.encode(logoutRedirectUri, StandardCharsets.UTF_8));
+
+        return params.toString();
+    }
+}

--- a/src/main/java/org/noostak/auth/dto/KakaoLogoutResponse.java
+++ b/src/main/java/org/noostak/auth/dto/KakaoLogoutResponse.java
@@ -1,0 +1,26 @@
+package org.noostak.auth.dto;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.noostak.auth.common.exception.KakaoApiErrorCode;
+import org.noostak.auth.common.exception.KakaoApiException;
+
+
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoLogoutResponse {
+    private String error;
+    private String errorDescription;
+    private String errorCode;
+
+    public void validate(){
+        if(error!= null){
+            throw new KakaoApiException(KakaoApiErrorCode.KAKAO_API_ERROR, errorDescription);
+        }
+    }
+}
+

--- a/src/main/java/org/noostak/auth/dto/KakaoUnlinkResponse.java
+++ b/src/main/java/org/noostak/auth/dto/KakaoUnlinkResponse.java
@@ -1,0 +1,28 @@
+package org.noostak.auth.dto;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.noostak.auth.common.exception.KakaoApiErrorCode;
+import org.noostak.auth.common.exception.KakaoApiException;
+
+
+@Getter
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoUnlinkResponse {
+    private String id;
+
+    private String error;
+    private String errorDescription;
+    private String errorCode;
+
+    public void validate(){
+        if(error!= null){
+            throw new KakaoApiException(KakaoApiErrorCode.KAKAO_API_ERROR, errorDescription);
+        }
+    }
+}
+

--- a/src/main/java/org/noostak/member/api/MemberController.java
+++ b/src/main/java/org/noostak/member/api/MemberController.java
@@ -31,4 +31,12 @@ public class MemberController {
         memberService.updateMember(memberId, request.getMemberName(), request.getMemberProfileImage());
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_UPDATE_COMPLETE));
     }
+
+    @DeleteMapping
+    public ResponseEntity<SuccessResponse> deleteMember(
+            @RequestAttribute Long memberId
+    ){
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_DELETE_COMPLETE));
+    }
 }

--- a/src/main/java/org/noostak/member/api/MemberController.java
+++ b/src/main/java/org/noostak/member/api/MemberController.java
@@ -11,32 +11,24 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/profile")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/profile")
+    @GetMapping
     public ResponseEntity<SuccessResponse> getProfile(@RequestAttribute Long memberId){
         GetProfileResponse response = memberService.fetchMember(memberId);
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_FETCH_COMPLETE,response));
     }
 
-    @PatchMapping("/profile")
+    @PatchMapping
     public ResponseEntity<SuccessResponse> updateProfile(
             @RequestAttribute Long memberId,
             @ModelAttribute UpdateProfileRequest request
             ){
         memberService.updateMember(memberId, request.getMemberName(), request.getMemberProfileImage());
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_UPDATE_COMPLETE));
-    }
-
-    @DeleteMapping("/auth/withdraw")
-    public ResponseEntity<SuccessResponse> deleteMember(
-            @RequestAttribute Long memberId
-    ){
-        memberService.deleteMember(memberId);
-        return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_DELETE_COMPLETE));
     }
 }

--- a/src/main/java/org/noostak/member/api/MemberController.java
+++ b/src/main/java/org/noostak/member/api/MemberController.java
@@ -11,19 +11,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/profile")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping
+    @GetMapping("/profile")
     public ResponseEntity<SuccessResponse> getProfile(@RequestAttribute Long memberId){
         GetProfileResponse response = memberService.fetchMember(memberId);
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_FETCH_COMPLETE,response));
     }
 
-    @PatchMapping
+    @PatchMapping("/profile")
     public ResponseEntity<SuccessResponse> updateProfile(
             @RequestAttribute Long memberId,
             @ModelAttribute UpdateProfileRequest request
@@ -32,7 +32,7 @@ public class MemberController {
         return ResponseEntity.ok(SuccessResponse.of(MemberSuccessCode.MEMBER_UPDATE_COMPLETE));
     }
 
-    @DeleteMapping
+    @DeleteMapping("/auth/withdraw")
     public ResponseEntity<SuccessResponse> deleteMember(
             @RequestAttribute Long memberId
     ){

--- a/src/main/java/org/noostak/member/application/MemberService.java
+++ b/src/main/java/org/noostak/member/application/MemberService.java
@@ -16,6 +16,6 @@ public interface MemberService {
     void updateMember(Long memberId, String memberName, MultipartFile image);
 
     // delete
-    void deleteMember();
+    void deleteMember(Long memberId);
 
 }

--- a/src/main/java/org/noostak/member/application/MemberServiceImpl.java
+++ b/src/main/java/org/noostak/member/application/MemberServiceImpl.java
@@ -3,6 +3,8 @@ package org.noostak.member.application;
 import org.noostak.infra.KeyAndUrl;
 import org.noostak.infra.S3DirectoryPath;
 import org.noostak.infra.S3Service;
+import org.noostak.member.common.exception.MemberErrorCode;
+import org.noostak.member.common.exception.MemberException;
 import org.noostak.member.domain.Member;
 import org.noostak.member.domain.MemberRepository;
 import org.noostak.member.domain.vo.MemberName;
@@ -75,7 +77,14 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void deleteMember() {
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.getById(memberId);
 
+        // 탈퇴 시 이미지 삭제
+        String removedProfileKey = member.getKey().value();
+        s3Service.deleteImage(removedProfileKey);
+
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/org/noostak/member/common/success/MemberSuccessCode.java
+++ b/src/main/java/org/noostak/member/common/success/MemberSuccessCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberSuccessCode implements SuccessCode {
     MEMBER_FETCH_COMPLETE(HttpStatus.OK,"멤버 프로필 조회에 성공했습니다."),
     MEMBER_UPDATE_COMPLETE(HttpStatus.OK,"프로필이 성공적으로 업데이트되었습니다."),
+    MEMBER_DELETE_COMPLETE(HttpStatus.OK,"회원 탈퇴에 성공하였습니다."),
     ;
 
 


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:**
  - 로그아웃 API 구현 및 회원 탈퇴 로직 수정하였습니다.
  
# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  -  로그아웃 API 구현
  - 탈퇴 로직에 Oauth 연동 해제 API 호출부 구현
  - 멤버 삭제 시 연동 정보를 삭제하여 Cascade.Remove 설정

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 로그아웃 시 내부에서 처리할 로직이 없어 따로 작성하지 않았습니다.
  - 기존 테스트 통과 확인 하였습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - GoogleServiceImpl에서 로그아웃 로직이 비어있는 이유는 다음과 같습니다.
    - 로그아웃에 대한 API가 별도로 존재하지 않음
    - 소셜 로그인 시 prompt = concent 임을 가정하여 매번 로그인을 시도하도록 설계

# 🎯 Related Issues
- #99 
