### PR TITLE
[🔧 fix] 약속 옵션의 생성 전략 변경

### DIFF
--- a/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionCommandServiceImpl.java
+++ b/src/main/java/org/noostak/appointment/application/recommendation/impl/AppointmentOptionCommandServiceImpl.java
@@ -20,8 +20,24 @@ public class AppointmentOptionCommandServiceImpl implements AppointmentOptionCom
     @Transactional
     public List<AppointmentOption> saveOptions(Appointment appointment, List<AppointmentOptionAvailabilityResponse> options) {
         return options.stream()
-                .map(dto -> appointmentOptionRepository.save(
-                        AppointmentOption.of(appointment, dto.date(), dto.startTime(), dto.endTime())))
+                .map(dto -> createAppointmentOption(appointment, dto))
                 .toList();
+    }
+
+    private AppointmentOption createAppointmentOption(Appointment appointment, AppointmentOptionAvailabilityResponse dto) {
+        AppointmentOption newOption =
+                AppointmentOption.of(appointment, dto.date(), dto.startTime(), dto.endTime());
+
+        AppointmentOption fetchedOption = getOptionByTimes(appointment,newOption);
+
+        if(fetchedOption != null){
+            return fetchedOption;
+        }
+
+        return appointmentOptionRepository.save(newOption);
+    }
+
+    private AppointmentOption getOptionByTimes(Appointment appointment, AppointmentOption appointmentOption){
+        return appointmentOptionRepository.getByAppointmentAndTimes(appointment,appointmentOption);
     }
 }

--- a/src/main/java/org/noostak/appointmentoption/domain/AppointmentOptionRepository.java
+++ b/src/main/java/org/noostak/appointmentoption/domain/AppointmentOptionRepository.java
@@ -1,9 +1,13 @@
 package org.noostak.appointmentoption.domain;
 
+import org.noostak.appointment.domain.Appointment;
 import org.noostak.likes.common.exception.LikesErrorCode;
 import org.noostak.likes.common.exception.LikesException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Repository
 public interface AppointmentOptionRepository extends JpaRepository<AppointmentOption, Long>, AppointmentOptionRepositoryCustom {
@@ -11,5 +15,13 @@ public interface AppointmentOptionRepository extends JpaRepository<AppointmentOp
     default AppointmentOption getByAppointmentOptionId(Long appointmentId){
         return findById(appointmentId)
                 .orElseThrow(() -> new LikesException(LikesErrorCode.OPTION_NOT_FOUND));
+    }
+
+    Optional<AppointmentOption> findFirstByAppointmentAndStartTimeAndEndTime
+            (Appointment appointment, LocalDateTime startTime, LocalDateTime endTime);
+
+    default AppointmentOption getByAppointmentAndTimes(Appointment appointment, AppointmentOption option){
+        return findFirstByAppointmentAndStartTimeAndEndTime(appointment,option.getStartTime(),option.getEndTime())
+                .orElse(null);
     }
 }

--- a/src/main/java/org/noostak/auth/dto/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/org/noostak/auth/dto/kakao/KakaoUserInfoResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.noostak.auth.common.exception.KakaoApiErrorCode;
 import org.noostak.auth.common.exception.KakaoApiException;
@@ -12,6 +13,7 @@ import org.noostak.auth.common.exception.KakaoApiException;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @ToString
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoUserInfoResponse {
@@ -35,6 +37,7 @@ public class KakaoUserInfoResponse {
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Properties {
         private String nickname;
@@ -43,6 +46,7 @@ public class KakaoUserInfoResponse {
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class KakaoAccount {
         private boolean profileNicknameNeedsAgreement;
@@ -51,6 +55,7 @@ public class KakaoUserInfoResponse {
 
         @Getter
         @AllArgsConstructor
+        @NoArgsConstructor
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
         public static class Profile {
             private String nickname;

--- a/src/test/java/org/noostak/appointmentoption/domain/AppointmentOptionRepositoryTest.java
+++ b/src/test/java/org/noostak/appointmentoption/domain/AppointmentOptionRepositoryTest.java
@@ -1,9 +1,11 @@
 package org.noostak.appointmentoption.domain;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.noostak.appointment.domain.Appointment;
 import org.noostak.appointmentoption.domain.vo.AppointmentOptionStatus;
 import org.springframework.data.domain.*;
 import org.springframework.data.repository.query.FluentQuery;
@@ -204,5 +206,11 @@ public class AppointmentOptionRepositoryTest implements AppointmentOptionReposit
     @Override
     public Page<AppointmentOption> findAll(Pageable pageable) {
         return null;
+    }
+
+    @Override
+    // TODO: 해당 코드를 활용한 테스트 코드로 수정할 것
+    public Optional<AppointmentOption> findFirstByAppointmentAndStartTimeAndEndTime(Appointment appointment, LocalDateTime startTime, LocalDateTime endTime) {
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:**
 - 약속 옵션의 생성 전략 변경하였습니다.

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - 새로운 AppointmentOption에 대해 Appointment와 시간이 이미 존재하다면, 저장하지 않고 해당 객체를 가져오도록 수정
  - 관련 Repository에  Appointment와 시작 시간, 종료 시간이 일치하는 Option을 가져오는 메소드 추가

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 기존 테스트 통과하였으나, 현재 변경사항에 대한 추가적인 테스트를 구현해야 합니다.
 
# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 현재 로직에 관련하여 우려되는 부분이 있는지 확인 부탁드립니다.

# 🎯 Related Issues
- #149 
