### PR TITLE
[♻️ refactor] 약속 추천 - 확정된 약속 조회 API 개선

### DIFF
--- a/src/main/java/org/noostak/appointment/common/success/AppointmentSuccessCode.java
+++ b/src/main/java/org/noostak/appointment/common/success/AppointmentSuccessCode.java
@@ -13,6 +13,8 @@ public enum AppointmentSuccessCode implements SuccessCode {
     APPOINTMENT_CONFIRMED(HttpStatus.OK, "약속이 성공적으로 확정되었습니다."),
 
     CONFIRMED_APPOINTMENT_RETRIEVED(HttpStatus.OK, "확정된 약속이 성공적으로 조회되었습니다."),
+
+    APPOINTMENT_OPTION_INFO_RETRIEVED(HttpStatus.OK, "약속 옵션이 성공적으로 조회되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/noostak/appointmentoption/api/AppointmentOptionController.java
+++ b/src/main/java/org/noostak/appointmentoption/api/AppointmentOptionController.java
@@ -1,7 +1,8 @@
 package org.noostak.appointmentoption.api;
 
 import lombok.RequiredArgsConstructor;
-import org.noostak.appointmentoption.application.AppointmentOptionService;
+import org.noostak.appointmentoption.application.info.AppointmentOptionService;
+import org.noostak.appointmentoption.dto.response.info.AppointmentOptionInfoResponse;
 import org.noostak.appointmentoption.dto.response.confirmed.AppointmentConfirmedOptionResponse;
 import org.noostak.global.success.SuccessResponse;
 import org.springframework.http.ResponseEntity;
@@ -32,5 +33,14 @@ public class AppointmentOptionController {
     ) {
         AppointmentConfirmedOptionResponse appointmentConfirmedOptionResponse = appointmentService.getConfirmedAppointmentOption(memberId, appointmentOptionId);
         return ResponseEntity.ok(SuccessResponse.of(CONFIRMED_APPOINTMENT_RETRIEVED, appointmentConfirmedOptionResponse));
+    }
+
+    @GetMapping("/{appointmentOptionId}")
+    public ResponseEntity<SuccessResponse> getAppointmentOption(
+            @RequestAttribute Long memberId,
+            @PathVariable Long appointmentOptionId
+    ) {
+        AppointmentOptionInfoResponse appointmentOptionInfoResponse = appointmentService.getAppointmentOptionInfo(memberId, appointmentOptionId);
+        return ResponseEntity.ok(SuccessResponse.of(CONFIRMED_APPOINTMENT_RETRIEVED, appointmentOptionInfoResponse));
     }
 }

--- a/src/main/java/org/noostak/appointmentoption/api/AppointmentOptionController.java
+++ b/src/main/java/org/noostak/appointmentoption/api/AppointmentOptionController.java
@@ -8,8 +8,7 @@ import org.noostak.global.success.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static org.noostak.appointment.common.success.AppointmentSuccessCode.APPOINTMENT_CONFIRMED;
-import static org.noostak.appointment.common.success.AppointmentSuccessCode.CONFIRMED_APPOINTMENT_RETRIEVED;
+import static org.noostak.appointment.common.success.AppointmentSuccessCode.*;
 
 @RestController
 @RequestMapping("/api/v1/appointment-options")
@@ -41,6 +40,6 @@ public class AppointmentOptionController {
             @PathVariable Long appointmentOptionId
     ) {
         AppointmentOptionInfoResponse appointmentOptionInfoResponse = appointmentService.getAppointmentOptionInfo(memberId, appointmentOptionId);
-        return ResponseEntity.ok(SuccessResponse.of(CONFIRMED_APPOINTMENT_RETRIEVED, appointmentOptionInfoResponse));
+        return ResponseEntity.ok(SuccessResponse.of(APPOINTMENT_OPTION_INFO_RETRIEVED, appointmentOptionInfoResponse));
     }
 }

--- a/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoService.java
+++ b/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoService.java
@@ -1,0 +1,8 @@
+package org.noostak.appointmentoption.application.info;
+
+
+import org.noostak.appointmentoption.dto.response.info.AppointmentOptionInfoResponse;
+
+public interface AppointmentOptionInfoService {
+    AppointmentOptionInfoResponse getAppointmentOptionInfo(Long memberId, Long appointmentOptionId);
+}

--- a/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoServiceImpl.java
+++ b/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoServiceImpl.java
@@ -1,0 +1,84 @@
+package org.noostak.appointmentoption.application.info;
+
+import lombok.RequiredArgsConstructor;
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointmentmember.domain.AppointmentMember;
+import org.noostak.appointmentmember.domain.AppointmentMemberRepository;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
+import org.noostak.appointmentoption.common.exception.AppointmentOptionErrorCode;
+import org.noostak.appointmentoption.common.exception.AppointmentOptionException;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentoption.domain.AppointmentOptionRepository;
+import org.noostak.appointmentoption.domain.vo.AppointmentOptionStatus;
+import org.noostak.appointmentoption.dto.response.info.AppointmentOptionInfoResponse;
+import org.noostak.appointmentoption.util.AppointmentOptionInfoOptionConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppointmentOptionInfoServiceImpl implements AppointmentOptionInfoService {
+
+    private final AppointmentOptionRepository appointmentOptionRepository;
+    private final AppointmentMemberRepository appointmentMemberRepository;
+
+    @Override
+    public AppointmentOptionInfoResponse getAppointmentOptionInfo(Long memberId, Long appointmentOptionId) {
+        AppointmentOption appointmentOption = findConfirmedAppointmentOption(appointmentOptionId);
+        Appointment appointment = appointmentOption.getAppointment();
+        List<AppointmentMember> appointmentMembers = findAppointmentMembers(appointment.getId());
+        AppointmentMember targetMember = findTargetMember(appointmentMembers, memberId);
+
+        Map<AppointmentAvailability, List<String>> groupedMembers = groupMembersByAvailability(appointmentMembers);
+        List<String> availableMemberNames = groupedMembers.getOrDefault(AppointmentAvailability.AVAILABLE, List.of());
+        List<String> unavailableMemberNames = groupedMembers.getOrDefault(AppointmentAvailability.UNAVAILABLE, List.of());
+
+        int memberIndex = findMemberIndexInLists(targetMember.getMember().getName().value(), availableMemberNames, unavailableMemberNames);
+
+        return AppointmentOptionInfoOptionConverter.toResponse(
+                appointmentOption, appointment, targetMember, availableMemberNames, unavailableMemberNames, memberIndex
+        );
+    }
+
+    private AppointmentOption findConfirmedAppointmentOption(Long appointmentOptionId) {
+        return appointmentOptionRepository.findById(appointmentOptionId)
+                .filter(option -> option.getStatus().equals(AppointmentOptionStatus.UNCONFIRMED))
+                .orElseThrow(() -> new AppointmentOptionException(AppointmentOptionErrorCode.APPOINTMENT_OPTION_NOT_FOUND));
+    }
+
+    private List<AppointmentMember> findAppointmentMembers(Long appointmentId) {
+        return appointmentMemberRepository.findByAppointmentId(appointmentId);
+    }
+
+    private AppointmentMember findTargetMember(List<AppointmentMember> appointmentMembers, Long memberId) {
+        return appointmentMembers.stream()
+                .filter(member -> member.getMember().getId().equals(memberId))
+                .findFirst()
+                .orElseThrow(() -> new AppointmentOptionException(AppointmentOptionErrorCode.APPOINTMENT_MEMBER_NOT_FOUND));
+    }
+
+    private Map<AppointmentAvailability, List<String>> groupMembersByAvailability(List<AppointmentMember> appointmentMembers) {
+        return appointmentMembers.stream()
+                .collect(Collectors.groupingBy(
+                        AppointmentMember::getAppointmentAvailability,
+                        Collectors.mapping(member -> member.getMember().getName().value(), Collectors.toList())
+                ));
+    }
+
+    private int findMemberIndexInLists(String memberName, List<String> availableMembers, List<String> unavailableMembers) {
+        if (availableMembers.contains(memberName)) {
+            return availableMembers.indexOf(memberName);
+        }
+        if (unavailableMembers.contains(memberName)) {
+            return unavailableMembers.indexOf(memberName);
+        }
+        return -1;
+    }
+
+
+}

--- a/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionService.java
+++ b/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionService.java
@@ -1,6 +1,9 @@
-package org.noostak.appointmentoption.application;
+package org.noostak.appointmentoption.application.info;
 
 import lombok.RequiredArgsConstructor;
+import org.noostak.appointmentoption.application.AppointmentOptionConfirmService;
+import org.noostak.appointmentoption.application.AppointmentOptionConfirmedOptionService;
+import org.noostak.appointmentoption.dto.response.info.AppointmentOptionInfoResponse;
 import org.noostak.appointmentoption.dto.response.confirmed.AppointmentConfirmedOptionResponse;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +13,7 @@ public class AppointmentOptionService {
 
     private final AppointmentOptionConfirmService confirmAppointment;
     private final AppointmentOptionConfirmedOptionService confirmedOptionService;
+    private final AppointmentOptionInfoService appointmentOptionInfoService;
 
     public void confirmAppointment(Long appointmentOptionId) {
         confirmAppointment.confirmAppointment(appointmentOptionId);
@@ -17,5 +21,9 @@ public class AppointmentOptionService {
 
     public AppointmentConfirmedOptionResponse getConfirmedAppointmentOption(Long memberId, Long appointmentOptionId) {
         return confirmedOptionService.getConfirmedAppointmentOption(memberId, appointmentOptionId);
+    }
+
+    public AppointmentOptionInfoResponse getAppointmentOptionInfo(Long memberId, Long appointmentOptionId) {
+        return appointmentOptionInfoService.getAppointmentOptionInfo(memberId, appointmentOptionId);
     }
 }

--- a/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoAvailableFriendsResponse.java
+++ b/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoAvailableFriendsResponse.java
@@ -1,0 +1,11 @@
+package org.noostak.appointmentoption.dto.response.info;
+
+import java.util.List;
+
+public record AppointmentOptionInfoAvailableFriendsResponse(int count,
+                                                            List<String> names
+) {
+    public static AppointmentOptionInfoAvailableFriendsResponse of(int count, List<String> names) {
+        return new AppointmentOptionInfoAvailableFriendsResponse(count, names);
+    }
+}

--- a/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoMyInfoResponse.java
+++ b/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoMyInfoResponse.java
@@ -1,0 +1,10 @@
+package org.noostak.appointmentoption.dto.response.info;
+
+public record AppointmentOptionInfoMyInfoResponse(String availability,
+                                                  int position,
+                                                  String name
+) {
+    public static AppointmentOptionInfoMyInfoResponse of(String availability, int position, String name) {
+        return new AppointmentOptionInfoMyInfoResponse(availability, position, name);
+    }
+}

--- a/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoResponse.java
+++ b/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoResponse.java
@@ -1,0 +1,13 @@
+package org.noostak.appointmentoption.dto.response.info;
+
+public record AppointmentOptionInfoResponse(AppointmentOptionInfoTimeResponse appointmentTime,
+                                            String category,
+                                            String appointmentName,
+                                            AppointmentOptionInfoMyInfoResponse myInfo,
+                                            AppointmentOptionInfoAvailableFriendsResponse availableFriends,
+                                            AppointmentOptionInfoUnavailableFriendsResponse unavailableFriends
+) {
+    public static AppointmentOptionInfoResponse of(AppointmentOptionInfoTimeResponse appointmentTime, String category, String appointmentName, AppointmentOptionInfoMyInfoResponse myInfo, AppointmentOptionInfoAvailableFriendsResponse availableFriends, AppointmentOptionInfoUnavailableFriendsResponse unavailableFriends) {
+        return new AppointmentOptionInfoResponse(appointmentTime, category, appointmentName, myInfo, availableFriends, unavailableFriends);
+    }
+}

--- a/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoTimeResponse.java
+++ b/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoTimeResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointmentoption.dto.response.info;
+
+import java.time.LocalDateTime;
+
+public record AppointmentOptionInfoTimeResponse(LocalDateTime date,
+                                                LocalDateTime startTime,
+                                                LocalDateTime endTime
+) {
+    public static AppointmentOptionInfoTimeResponse of(LocalDateTime date, LocalDateTime startTime, LocalDateTime endTime) {
+        return new AppointmentOptionInfoTimeResponse(date, startTime, endTime);
+    }
+}

--- a/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoUnavailableFriendsResponse.java
+++ b/src/main/java/org/noostak/appointmentoption/dto/response/info/AppointmentOptionInfoUnavailableFriendsResponse.java
@@ -1,0 +1,12 @@
+package org.noostak.appointmentoption.dto.response.info;
+
+import java.util.List;
+
+public record AppointmentOptionInfoUnavailableFriendsResponse(int count,
+                                                              List<String> names
+) {
+    public static AppointmentOptionInfoUnavailableFriendsResponse of(int count, List<String> names) {
+        return new AppointmentOptionInfoUnavailableFriendsResponse(count, names);
+    }
+}
+

--- a/src/main/java/org/noostak/appointmentoption/util/AppointmentOptionInfoOptionConverter.java
+++ b/src/main/java/org/noostak/appointmentoption/util/AppointmentOptionInfoOptionConverter.java
@@ -1,0 +1,55 @@
+package org.noostak.appointmentoption.util;
+
+import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointmentmember.domain.AppointmentMember;
+import org.noostak.appointmentoption.domain.AppointmentOption;
+import org.noostak.appointmentoption.dto.response.info.*;
+
+import java.util.List;
+
+public class AppointmentOptionInfoOptionConverter {
+
+    public static AppointmentOptionInfoResponse toResponse(
+            AppointmentOption appointmentOption, Appointment appointment, AppointmentMember targetMember,
+            List<String> availableMemberNames, List<String> unavailableMemberNames, int memberIndex) {
+
+        return AppointmentOptionInfoResponse.of(
+                toTimeResponse(appointmentOption),
+                appointment.getCategory().getMessage(),
+                appointment.getName().value(),
+                toMyInfoResponse(targetMember, memberIndex),
+                toAvailableFriendsResponse(availableMemberNames),
+                toUnavailableFriendsResponse(unavailableMemberNames)
+        );
+    }
+
+    private static AppointmentOptionInfoTimeResponse toTimeResponse(AppointmentOption appointmentOption) {
+        return AppointmentOptionInfoTimeResponse.of(
+                appointmentOption.getDate(),
+                appointmentOption.getStartTime(),
+                appointmentOption.getEndTime()
+        );
+    }
+
+    private static AppointmentOptionInfoMyInfoResponse toMyInfoResponse(AppointmentMember targetMember, int memberIndex) {
+        return AppointmentOptionInfoMyInfoResponse.of(
+                targetMember.getAppointmentAvailability().getMessage(),
+                memberIndex,
+                targetMember.getMember().getName().value()
+        );
+    }
+
+    private static AppointmentOptionInfoAvailableFriendsResponse toAvailableFriendsResponse(List<String> availableMemberNames) {
+        return AppointmentOptionInfoAvailableFriendsResponse.of(
+                availableMemberNames.size(),
+                availableMemberNames
+        );
+    }
+
+    private static AppointmentOptionInfoUnavailableFriendsResponse toUnavailableFriendsResponse(List<String> unavailableMemberNames) {
+        return AppointmentOptionInfoUnavailableFriendsResponse.of(
+                unavailableMemberNames.size(),
+                unavailableMemberNames
+        );
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- 작업 내용 요약:
- DTO, Service, Converter를 구현하여 ‘약속 옵션 정보 조회’ 기능을 추가했습니다.
해당 약속 옵션 ID에 대해, 약속에 참여한 멤버들의 가용성 정보를 반환할 수 있는 기능과 DTO를 포함합니다.

# 🛠️ What’s been done?
- 약속 옵션에 참여한 멤버의 가용성 상태(가용 / 비가용)를 구분하고, 각 상태별 멤버 이름 목록을 DTO로 변환하는 Converter를 구현했습니다.
  - AppointmentOptionInfoResponse 출력을 위한 다양한 정보를 가지는 DTO를 복합적으로 구성하여 구현
  - AppointmentOptionInfoService의 getAppointmentOptionInfo() 메서드 구현
  - 약속에 참여한 멤버를 가용 / 비가용 상태로 분류하여 DTO에 포함
  - AppointmentOptionInfoOptionConverter를 구현하여 데이터를 DTO로 변환
  - 기존의 "확정된 약속 정보" API와 공통되는 데이터 구조가 일부 있어, 해당 변환 로직을 개선하여 재사용할 계획입니다.
- 기존에 구현된 "확정된 약속 정보" API와 일반된 정보가 중복되는 단계가 있어, 해당 변환 목록을 개선해 재사용할 계획입니다.

# 🧪 Testing Details
![스크린샷 2025-04-02 오전 10 32 35](https://github.com/user-attachments/assets/f4fb8d94-10ab-415b-a242-c1c3a1b35afd)


# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - 데이터 구조가 맞게 나가고 있는지 (모든 정보가 필요하게 다루어지는지)
  - Converter 내 목적이 명확하게 나타나는지
  - Member Index 계산 목적 가능성

# 🌟 Related Issues
- closes #202 

