### PR TITLE
[♻️ refactor] 약속 옵션 조회 관련 로직 수정 

### DIFF
--- a/src/main/java/org/noostak/appointment/util/AppointmentOptionResponseMapper.java
+++ b/src/main/java/org/noostak/appointment/util/AppointmentOptionResponseMapper.java
@@ -11,6 +11,7 @@ import org.noostak.likes.domain.LikeRepository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AppointmentOptionResponseMapper {
 
@@ -23,7 +24,7 @@ public class AppointmentOptionResponseMapper {
             GroupRepository groupRepository
     ) {
         List<Long> availableMembers = findAvailableMembers(option, memberAvailability);
-        List<Long> unavailableMembers = findUnavailableMembers(memberAvailability, availableMembers);
+        List<Long> unavailableMembers = findUnavailableMembers(availableMembers, memberNames);
         String myName = findMemberName(memberId, memberNames);
         boolean isAvailable = availableMembers.contains(memberId);
         Long position = findMemberPosition(isAvailable, memberId, availableMembers, unavailableMembers);
@@ -52,10 +53,14 @@ public class AppointmentOptionResponseMapper {
     }
 
     private static List<Long> findUnavailableMembers(
-            Map<Long, List<AppointmentMemberAvailableTime>> memberAvailability,
-            List<Long> availableMembers
+            List<Long> availableMembers,
+            Map<Long, String> allMemberNames // TODO: 약속에 관계된 모든 Member의 이름 (선택자 + 미선택자 포함) 로직 변경 시 지우기
     ) {
-        return memberAvailability.keySet().stream()
+
+        // 시간을 선택하지 않은 멤버들도 불가능한 약속에 포함
+        Set<Long> allMembersId = allMemberNames.keySet();
+
+        return allMembersId.stream()
                 .filter(id -> !availableMembers.contains(id))
                 .toList();
     }

--- a/src/main/java/org/noostak/appointmentmember/application/AppointmentMemberSaveServiceImpl.java
+++ b/src/main/java/org/noostak/appointmentmember/application/AppointmentMemberSaveServiceImpl.java
@@ -30,7 +30,7 @@ public class AppointmentMemberSaveServiceImpl implements AppointmentMemberSaveSe
     @Transactional
     public void saveAppointmentMember(Appointment appointment, Member member) {
         AppointmentMember newAppointmentMember = AppointmentMember.of(
-                AppointmentAvailability.NOT_SELECTED,
+                AppointmentAvailability.UNAVAILABLE,
                 appointment,
                 member);
 

--- a/src/main/java/org/noostak/appointmentmember/domain/vo/AppointmentAvailability.java
+++ b/src/main/java/org/noostak/appointmentmember/domain/vo/AppointmentAvailability.java
@@ -9,7 +9,7 @@ public enum AppointmentAvailability {
 
     AVAILABLE("약속 가능"),
     UNAVAILABLE("약속 불가능"),
-    NOT_SELECTED("선택 안 함")
+
     ;
 
     private final String message;

--- a/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoServiceImpl.java
+++ b/src/main/java/org/noostak/appointmentoption/application/info/AppointmentOptionInfoServiceImpl.java
@@ -2,7 +2,11 @@ package org.noostak.appointmentoption.application.info;
 
 import lombok.RequiredArgsConstructor;
 import org.noostak.appointment.domain.Appointment;
+import org.noostak.appointment.util.AppointmentAvailabilityMatcher;
+import org.noostak.appointment.util.TimeSlot;
 import org.noostak.appointmentmember.domain.AppointmentMember;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTime;
+import org.noostak.appointmentmember.domain.AppointmentMemberAvailableTimesRepository;
 import org.noostak.appointmentmember.domain.AppointmentMemberRepository;
 import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
 import org.noostak.appointmentoption.common.exception.AppointmentOptionErrorCode;
@@ -26,23 +30,63 @@ public class AppointmentOptionInfoServiceImpl implements AppointmentOptionInfoSe
 
     private final AppointmentOptionRepository appointmentOptionRepository;
     private final AppointmentMemberRepository appointmentMemberRepository;
+    private final AppointmentMemberAvailableTimesRepository availableTimesRepository;
 
     @Override
     public AppointmentOptionInfoResponse getAppointmentOptionInfo(Long memberId, Long appointmentOptionId) {
-        AppointmentOption appointmentOption = findConfirmedAppointmentOption(appointmentOptionId);
+        AppointmentOption appointmentOption = findByAppointmentOptionId(appointmentOptionId);
         Appointment appointment = appointmentOption.getAppointment();
         List<AppointmentMember> appointmentMembers = findAppointmentMembers(appointment.getId());
         AppointmentMember targetMember = findTargetMember(appointmentMembers, memberId);
 
-        Map<AppointmentAvailability, List<String>> groupedMembers = groupMembersByAvailability(appointmentMembers);
-        List<String> availableMemberNames = groupedMembers.getOrDefault(AppointmentAvailability.AVAILABLE, List.of());
-        List<String> unavailableMemberNames = groupedMembers.getOrDefault(AppointmentAvailability.UNAVAILABLE, List.of());
+        List<String> availableMemberNames =
+                getAvailableMemberNames(appointmentOption, appointmentMembers);
+
+        List<String> unavailableMemberNames =
+                getUnavailableMembers(appointmentMembers, availableMemberNames);
 
         int memberIndex = findMemberIndexInLists(targetMember.getMember().getName().value(), availableMemberNames, unavailableMemberNames);
 
         return AppointmentOptionInfoOptionConverter.toResponse(
                 appointmentOption, appointment, targetMember, availableMemberNames, unavailableMemberNames, memberIndex
         );
+    }
+
+    private static List<String> getUnavailableMembers(List<AppointmentMember> appointmentMembers,
+                                                      List<String> availableMemberNames) {
+        return appointmentMembers.stream()
+                .filter(appointmentMember -> !availableMemberNames.contains(appointmentMember.getMember().getName().value()))
+                .map(appointmentMember -> appointmentMember.getMember().getName().value())
+                .toList();
+    }
+
+    private List<String> getAvailableMemberNames(AppointmentOption appointmentOption,
+                                                 List<AppointmentMember> appointmentMembers) {
+        return appointmentMembers.stream()
+                .filter(appointmentMember -> isAvailableMember(appointmentOption, appointmentMember))
+                .map(appointmentMember -> appointmentMember.getMember().getName().value())
+                .toList();
+    }
+
+    private boolean isAvailableMember(AppointmentOption option, AppointmentMember appointmentMember){
+        // 약속 멤버에 대한 가능한 시간 약속들을 조회
+        List<AppointmentMemberAvailableTime> memberTimes =
+                availableTimesRepository.findByAppointmentMember(appointmentMember);
+
+        // 가능한 시간이 입력되지 않은 상태이거나, 가능한 시간이 비어있다면 해당 옵션에서 불가능한 멤버로 판단
+        if(!appointmentMember.isAppointmentTimeSet() || memberTimes.isEmpty()){
+            return false;
+        }
+
+        // 옵션에 대해 시간을 만족하는지 확인
+        return AppointmentAvailabilityMatcher
+                .satisfiesDuration(
+                        memberTimes,
+                        TimeSlot.of(option.getDate(), option.getStartTime(), option.getEndTime()));
+    }
+
+    private AppointmentOption findByAppointmentOptionId(Long appointmentOptionId) {
+        return appointmentOptionRepository.getByAppointmentOptionId(appointmentOptionId);
     }
 
     private AppointmentOption findConfirmedAppointmentOption(Long appointmentOptionId) {

--- a/src/main/java/org/noostak/appointmentoption/domain/AppointmentOptionRepository.java
+++ b/src/main/java/org/noostak/appointmentoption/domain/AppointmentOptionRepository.java
@@ -1,8 +1,8 @@
 package org.noostak.appointmentoption.domain;
 
 import org.noostak.appointment.domain.Appointment;
-import org.noostak.likes.common.exception.LikesErrorCode;
-import org.noostak.likes.common.exception.LikesException;
+import org.noostak.appointmentoption.common.exception.AppointmentOptionErrorCode;
+import org.noostak.appointmentoption.common.exception.AppointmentOptionException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,7 +14,7 @@ public interface AppointmentOptionRepository extends JpaRepository<AppointmentOp
 
     default AppointmentOption getByAppointmentOptionId(Long appointmentOptionId){
         return findById(appointmentOptionId)
-                .orElseThrow(() -> new LikesException(LikesErrorCode.OPTION_NOT_FOUND));
+                .orElseThrow(() -> new AppointmentOptionException(AppointmentOptionErrorCode.APPOINTMENT_OPTION_NOT_FOUND));
     }
 
     Optional<AppointmentOption> findFirstByAppointmentAndStartTimeAndEndTime

--- a/src/main/java/org/noostak/appointmentoption/util/AppointmentOptionInfoOptionConverter.java
+++ b/src/main/java/org/noostak/appointmentoption/util/AppointmentOptionInfoOptionConverter.java
@@ -2,6 +2,7 @@ package org.noostak.appointmentoption.util;
 
 import org.noostak.appointment.domain.Appointment;
 import org.noostak.appointmentmember.domain.AppointmentMember;
+import org.noostak.appointmentmember.domain.vo.AppointmentAvailability;
 import org.noostak.appointmentoption.domain.AppointmentOption;
 import org.noostak.appointmentoption.dto.response.info.*;
 
@@ -17,7 +18,7 @@ public class AppointmentOptionInfoOptionConverter {
                 toTimeResponse(appointmentOption),
                 appointment.getCategory().getMessage(),
                 appointment.getName().value(),
-                toMyInfoResponse(targetMember, memberIndex),
+                toMyInfoResponse(availableMemberNames, targetMember, memberIndex),
                 toAvailableFriendsResponse(availableMemberNames),
                 toUnavailableFriendsResponse(unavailableMemberNames)
         );
@@ -31,11 +32,22 @@ public class AppointmentOptionInfoOptionConverter {
         );
     }
 
-    private static AppointmentOptionInfoMyInfoResponse toMyInfoResponse(AppointmentMember targetMember, int memberIndex) {
+    private static AppointmentOptionInfoMyInfoResponse toMyInfoResponse(
+            List<String> availableMemberNames,
+            AppointmentMember targetMember,
+            int memberIndex) {
+        String targetMemberName = targetMember.getMember().getName().value();
+        AppointmentAvailability appointmentAvailability = targetMember.getAppointmentAvailability();
+
+        // 만약, 가능한 멤버에 속해있다면 AVAILABLE로 반환하기
+        if(availableMemberNames.contains(targetMemberName)){
+            appointmentAvailability = AppointmentAvailability.AVAILABLE;
+        }
+
         return AppointmentOptionInfoMyInfoResponse.of(
-                targetMember.getAppointmentAvailability().getMessage(),
+                appointmentAvailability.getMessage(),
                 memberIndex,
-                targetMember.getMember().getName().value()
+                targetMemberName
         );
     }
 


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 이 PR에서 해결하거나 추가한 내용을 간략히 설명해 주세요.
  - 약속 옵션 조회 관련 로직 수정 

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - 약속 - 옵션 상세 조회 시, 확정된 약속을 조회하는 것이 아닌 단순 findById로 조회 하도록 수정
  - 약속 - 옵션 상세 조회 시, AppointmentMember의 startTime, endTime과 Option과의 startTime, endTime 시간 비교를 통하여 약속 가능과 약속 불가능 여부를 지정하고, 가능, 불가능 멤버 이름 리스트에 포함하도록 수정
  - 약속 - 옵션 상세 조회 시, AppointmentMember의 AppointmentStatus를 반환하지 않고, 위의 시간 비교를 통해 약속 가능과 약속 불가능 여부를 myInfo에 표시하여 반환하도록 변경
  - 약속 - 약속 옵션 조회(추천된 약속 조회) 시, AppointmentMemberAvailableTimes가 존재하지 않는 AppointmentMember도 약속이 불가능한 친구 이름 리스트에 포함되도록 수정
  - NOT_SELECTED 상태 삭제 (해당 부분은 appointmentTimeSet의 true/false 여부로 파악할 수 있음. 중복 표현)
약속 멤버 저장 시, 기본적으로 UNAVAILABLE 상태를 가지도록 수정

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 기존 테스트 통과하였습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  -  문제를 해결하기 위해 기존 작성하신 코드가 변경되었으니 양해 부탁드립니다.

# 🎯 Related Issues
- #213 
